### PR TITLE
Fix login: point app at workers.dev API URL

### DIFF
--- a/phone/config.js
+++ b/phone/config.js
@@ -2,10 +2,10 @@
 // Edit these two values to match your deployment.
 window.LINEAR_PHONE_CONFIG = {
   // Base URL of your Cloudflare Worker API.
-  // Recommended: map the linear-ivr worker to a custom domain (api.linearit.co)
-  // so the softphone and API share a registrable domain (best for Safari/iPad).
-  // You can also use the raw workers.dev URL during testing.
-  API_BASE: "https://api.linearit.co",
+  // Using the worker's built-in URL (works immediately, no DNS setup).
+  // If you later map the worker to a custom domain (e.g. api.linearit.co),
+  // change this to that and update ALLOW_ORIGIN on the worker to match.
+  API_BASE: "https://linear-ivr.friedmanchaimhersh.workers.dev",
 
   // Your SignalWire phone number in E.164 format (this is the caller ID for
   // outbound calls and the "From" for texts). 845-604-2025:

--- a/worker/schema.sql
+++ b/worker/schema.sql
@@ -1,44 +1,37 @@
--- Linear Phone — D1 schema
--- Apply with:  wrangler d1 execute linear_phone --file=worker/schema.sql --remote
--- (or paste into the D1 console in the Cloudflare dashboard)
-
 CREATE TABLE IF NOT EXISTS messages (
-  id         INTEGER PRIMARY KEY AUTOINCREMENT,
-  number     TEXT NOT NULL,            -- the other party, E.164
-  direction  TEXT NOT NULL,            -- 'in' | 'out'
-  body       TEXT NOT NULL,
-  sid        TEXT,                     -- SignalWire MessageSid
-  is_read    INTEGER NOT NULL DEFAULT 0,
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  number TEXT NOT NULL,
+  direction TEXT NOT NULL,
+  body TEXT NOT NULL,
+  sid TEXT,
+  is_read INTEGER NOT NULL DEFAULT 0,
   created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 CREATE INDEX IF NOT EXISTS idx_messages_number ON messages(number);
 CREATE INDEX IF NOT EXISTS idx_messages_created ON messages(created_at);
-
 CREATE TABLE IF NOT EXISTS calls (
-  id         INTEGER PRIMARY KEY AUTOINCREMENT,
-  number     TEXT NOT NULL,
-  direction  TEXT NOT NULL,            -- 'in' | 'out'
-  status     TEXT,                     -- 'completed' | 'missed' | 'no-answer' | 'busy'
-  duration   INTEGER DEFAULT 0,        -- seconds
-  sid        TEXT,
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  number TEXT NOT NULL,
+  direction TEXT NOT NULL,
+  status TEXT,
+  duration INTEGER DEFAULT 0,
+  sid TEXT,
   created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 CREATE INDEX IF NOT EXISTS idx_calls_created ON calls(created_at);
-
 CREATE TABLE IF NOT EXISTS voicemail (
-  id            INTEGER PRIMARY KEY AUTOINCREMENT,
-  number        TEXT NOT NULL,
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  number TEXT NOT NULL,
   recording_url TEXT,
-  transcript    TEXT,
-  sid           TEXT,
-  is_read       INTEGER NOT NULL DEFAULT 0,
-  created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+  transcript TEXT,
+  sid TEXT,
+  is_read INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
-
 CREATE TABLE IF NOT EXISTS contacts (
-  id         INTEGER PRIMARY KEY AUTOINCREMENT,
-  name       TEXT NOT NULL,
-  number     TEXT NOT NULL,
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL,
+  number TEXT NOT NULL,
   created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 CREATE UNIQUE INDEX IF NOT EXISTS idx_contacts_number ON contacts(number);


### PR DESCRIPTION
Fixes login: the app was pointed at `https://api.linearit.co` (custom domain that isn't set up), so requests never reached the worker. Repoints `API_BASE` to the worker's built-in `workers.dev` URL — works with no DNS setup. Also strips comments from `schema.sql` so it pastes cleanly into the D1 web console.

Note: the worker's `ALLOW_ORIGIN` secret must be `https://www.linearit.co` (the site serves at www; apex redirects there).

https://claude.ai/code/session_0178AobHq5H5WY5tmr5VvnpC

---
_Generated by [Claude Code](https://claude.ai/code/session_0178AobHq5H5WY5tmr5VvnpC)_