### PR TITLE
Linear Phone: browser calling via SignalWire Call Fabric

### DIFF
--- a/phone/DEPLOY.md
+++ b/phone/DEPLOY.md
@@ -93,15 +93,13 @@ In SignalWire → **Phone Numbers** → **845-604-2025** → **Edit Settings**:
 
 Inbound browser ringing uses SignalWire's **Call Fabric Subscriber** system: the
 app logs in as a Subscriber with a token (no SIP), so it can receive calls in any
-browser on any device. Three one-time steps:
+browser on any device. The Worker **creates the Subscriber automatically** the
+first time you log in, so there's no Subscribers screen to hunt for.
 
-**5a. Create the Subscriber** (this is the identity the browser logs in as)
-- SignalWire dashboard → left nav **Subscribers** (under *Call Fabric* / *Resources*)
-  → **Create / Add Subscriber**.
-- Give it a name/username and password. Note the **name** — it becomes the
-  address `/private/<name>`.
-- In the Worker, set secret **`SUBSCRIBER_REFERENCE`** to that exact name
-  (e.g. `linearphone`). Also confirm **`GOOGLE_VOICE_NUMBER`** = `+19177270405`.
+**5a. Set the Subscriber name** (Worker secret)
+- In the Worker, set **`SUBSCRIBER_REFERENCE`** = `linearphone` and confirm
+  **`GOOGLE_VOICE_NUMBER`** = `+19177270405`. That's it — logging into the app
+  once provisions the Subscriber `/private/linearphone`.
 
 **5b. Point your number at the SWML handler**
 - SignalWire → **Phone Numbers** → **845-604-2025** → **Edit Settings**.

--- a/phone/DEPLOY.md
+++ b/phone/DEPLOY.md
@@ -89,21 +89,37 @@ In SignalWire → **Phone Numbers** → **845-604-2025** → **Edit Settings**:
 
 ---
 
-## 5) (Optional) Ring the browser on inbound calls
+## 5) Ring the browser on inbound calls (Call Fabric)
 
-Texting + outbound calling work after steps 1–4. To make inbound calls **ring
-in the browser** (not just your cell/voicemail), SignalWire needs to route the
-call to your RELAY client:
+Inbound browser ringing uses SignalWire's **Call Fabric Subscriber** system: the
+app logs in as a Subscriber with a token (no SIP), so it can receive calls in any
+browser on any device. Three one-time steps:
 
-- Easiest reliable version: in the SignalWire number's voice settings, the
-  Worker's `/voice` handler already does `<Dial>` to `FORWARD_NUMBER` if set —
-  so set `FORWARD_NUMBER` to your cell and inbound calls ring your phone while
-  unanswered calls drop to voicemail (which shows up in the app).
-- Full in-browser ringing uses a RELAY Application/context. Set `RELAY_CONTEXT`
-  (e.g. `linearphone`) as a Worker secret; the minted JWT is scoped to it. Then
-  in SignalWire, route the number to that RELAY context. This part depends on
-  your SignalWire account's RELAY setup — ping me and I'll wire the exact
-  routing once your number is live on the Worker.
+**5a. Create the Subscriber** (this is the identity the browser logs in as)
+- SignalWire dashboard → left nav **Subscribers** (under *Call Fabric* / *Resources*)
+  → **Create / Add Subscriber**.
+- Give it a name/username and password. Note the **name** — it becomes the
+  address `/private/<name>`.
+- In the Worker, set secret **`SUBSCRIBER_REFERENCE`** to that exact name
+  (e.g. `linearphone`). Also confirm **`GOOGLE_VOICE_NUMBER`** = `+19177270405`.
+
+**5b. Point your number at the SWML handler**
+- SignalWire → **Phone Numbers** → **845-604-2025** → **Edit Settings**.
+- Under **Voice and Fax** → **Handle Calls Using:** choose **a SWML Script**.
+- Check **"Use External URL for SWML Script handler?"**
+- **External URL:** `https://linear-ivr.friedmanchaimhersh.workers.dev/swml/voice`
+  (POST). **Save.**
+
+**5c. Open the app and stay signed in**
+- Go to **https://linearit.co/phone**, log in, allow the mic. The status pill
+  should read **Online**.
+- Call your number from another phone: your browser rings for ~18s. If you don't
+  pick up, it rings your Google Voice (+19177270405) for ~25s, which has its own
+  voicemail.
+
+> The old `/ivr` cXML webhook still works as a safe fallback (greeting → Google
+> Voice). Switching the number to `/swml/voice` in 5b is what turns on browser
+> ringing.
 
 ---
 
@@ -115,9 +131,12 @@ the foundation for a future React-Native/Capacitor mobile build.
 
 ## Troubleshooting
 
-- **"Phone not connected" / status stays Offline:** the RELAY JWT couldn't be
-  minted — check `SIGNALWIRE_SPACE`, `SIGNALWIRE_PROJECT`, `SIGNALWIRE_TOKEN`.
-  Open the browser console for the exact error.
+- **Status stays Offline / a red error toast appears:** the Subscriber token
+  couldn't be minted — check `SIGNALWIRE_SPACE`, `SIGNALWIRE_PROJECT`,
+  `SIGNALWIRE_TOKEN`, and that the **Subscriber** (step 5a) exists and matches
+  `SUBSCRIBER_REFERENCE`. The on-screen toast shows the exact reason.
+- **Browser doesn't ring, calls go straight to Google Voice:** the number isn't
+  pointed at `/swml/voice` yet (step 5b), or the app isn't open/Online.
 - **Texts send but don't appear inbound:** confirm the **Message Comes In**
   webhook points to `/sms/inbound` and the D1 `DB` binding is attached.
 - **Login fails:** `APP_PASSWORD` mismatch, or `AUTH_SECRET` not set.

--- a/phone/api.js
+++ b/phone/api.js
@@ -31,8 +31,8 @@
     },
     logout: () => setToken(""),
 
-    // Realtime token for the WebRTC browser client
-    rtcToken: () => req("/api/token", { method: "POST" }),
+    // SIP credentials for the browser WebRTC softphone
+    sipCreds: () => req("/api/sip-creds"),
 
     // Messaging
     threads: () => req("/api/threads"),

--- a/phone/api.js
+++ b/phone/api.js
@@ -31,8 +31,8 @@
     },
     logout: () => setToken(""),
 
-    // SIP credentials for the browser WebRTC softphone
-    sipCreds: () => req("/api/sip-creds"),
+    // Call Fabric Subscriber token for the browser WebRTC client
+    rtcToken: () => req("/api/token", { method: "POST" }),
 
     // Messaging
     threads: () => req("/api/threads"),

--- a/phone/app.js
+++ b/phone/app.js
@@ -329,7 +329,8 @@
   function initVoice() {
     Voice.init({
       remoteAudio: $("#remoteAudio"),
-      getSipCreds: () => API.sipCreds(),
+      rootElement: $("#callMedia"),
+      getRtcToken: () => API.rtcToken(),
       myNumber: CFG.MY_NUMBER,
       onStatus: (status) => {
         const el = $("#phoneStatus");
@@ -337,6 +338,7 @@
         const [txt, cls] = map[status] || map.offline;
         el.textContent = txt; el.className = "text-[11px] px-2 py-1 rounded-full " + cls;
       },
+      onError: (msg) => { toast(msg); console.warn("[Voice]", msg); },
       onIncoming: (number) => {
         showCallOverlay({ name: displayName(number), state: "Incoming call…", incoming: true });
       },

--- a/phone/app.js
+++ b/phone/app.js
@@ -329,7 +329,7 @@
   function initVoice() {
     Voice.init({
       remoteAudio: $("#remoteAudio"),
-      getRtcToken: () => API.rtcToken(),
+      getSipCreds: () => API.sipCreds(),
       myNumber: CFG.MY_NUMBER,
       onStatus: (status) => {
         const el = $("#phoneStatus");

--- a/phone/index.html
+++ b/phone/index.html
@@ -186,6 +186,8 @@
 
 <!-- audio sink for remote party -->
 <audio id="remoteAudio" autoplay playsinline></audio>
+<!-- SignalWire injects call media here (kept off-screen; audio-only) -->
+<div id="callMedia" style="position:absolute;width:0;height:0;overflow:hidden"></div>
 
 <!-- ========================= CONTACT EDIT MODAL ========================= -->
 <div id="contactModal" class="hidden fixed inset-0 z-50 bg-black/40 grid place-items-center p-6">
@@ -208,7 +210,7 @@
 <div id="toast" class="hidden fixed top-4 left-1/2 -translate-x-1/2 z-[60] bg-ink text-white text-sm px-4 py-2 rounded-full shadow-lg"></div>
 
 <!-- SignalWire RELAY browser SDK (WebRTC calling). Pinned to the v1 line. -->
-<script src="https://unpkg.com/jssip@3.10.1/dist/jssip.min.js"></script>
+<script src="https://cdn.signalwire.com/@signalwire/js"></script>
 <script src="config.js"></script>
 <script src="api.js"></script>
 <script src="voice.js"></script>

--- a/phone/index.html
+++ b/phone/index.html
@@ -208,7 +208,7 @@
 <div id="toast" class="hidden fixed top-4 left-1/2 -translate-x-1/2 z-[60] bg-ink text-white text-sm px-4 py-2 rounded-full shadow-lg"></div>
 
 <!-- SignalWire RELAY browser SDK (WebRTC calling). Pinned to the v1 line. -->
-<script src="https://unpkg.com/@signalwire/js@1.5.1-rc.5/dist/index.min.js"></script>
+<script src="https://unpkg.com/jssip@3.10.1/dist/jssip.min.js"></script>
 <script src="config.js"></script>
 <script src="api.js"></script>
 <script src="voice.js"></script>

--- a/phone/voice.js
+++ b/phone/voice.js
@@ -1,110 +1,139 @@
-// Linear Phone — WebRTC voice module (SignalWire RELAY browser SDK)
-// Uses the RELAY v2 browser client which dials PSTN numbers directly with
-// caller ID. Texting still works even if this module can't connect.
+// Linear Phone — WebRTC voice module (SIP-over-WebSocket via JsSIP)
+// Registers the browser as the "ipad1" SIP endpoint on SignalWire.
+// Inbound PSTN calls reach the browser via <Dial><Sip>sip:ipad1@domain</Sip></Dial> in the IVR.
 window.Voice = (function () {
-  let client = null;
-  let currentCall = null;
+  let ua = null;
+  let sipDomain = "";
+  let currentSession = null;
   let cbs = {};
   let muted = false;
-  let speaker = true;
   let callStartedAt = 0;
   let callNumber = "";
   let callDirection = "out";
 
-  // The RELAY SDK exposes itself differently depending on the build.
-  function getRelay() {
-    if (window.Relay) return window.Relay;
-    if (window.SignalWire && window.SignalWire.Relay) return window.SignalWire.Relay;
-    return null;
-  }
-
   async function init(options) {
     cbs = options || {};
-    const Relay = getRelay();
-    if (!Relay) {
-      console.warn("[Voice] RELAY SDK not loaded — calling disabled, texting still works.");
-      status("offline");
+    const onStatus = (s) => cbs.onStatus && cbs.onStatus(s);
+    if (!window.JsSIP) {
+      console.warn("[Voice] JsSIP not loaded — calling disabled.");
+      onStatus("offline");
       return;
     }
-    status("connecting");
+    onStatus("connecting");
     try {
-      const { token, project } = await cbs.getRtcToken();
-      client = new Relay({ project, token });
-      // Where the remote party's audio plays:
-      if (cbs.remoteAudio) client.remoteElement = cbs.remoteAudio.id || "remoteAudio";
-      client.iceServers = client.iceServers; // keep defaults
+      const creds = await cbs.getSipCreds();
+      if (!creds || !creds.domain || !creds.user || !creds.password) {
+        throw new Error("SIP credentials not configured (WEBPHONE_SIP_USER/DOMAIN/WEBRTC_PASSWORD)");
+      }
+      sipDomain = creds.domain;
+      JsSIP.debug.disable("JsSIP:*");
 
-      client.on("signalwire.ready", () => status("ready"));
-      client.on("signalwire.error", (e) => { console.error("[Voice] error", e); status("offline"); });
-      client.on("signalwire.socket.close", () => status("offline"));
-      client.on("signalwire.notification", handleNotification);
+      const socket = new JsSIP.WebSocketInterface("wss://" + sipDomain);
+      ua = new JsSIP.UA({
+        sockets: [socket],
+        uri: "sip:" + creds.user + "@" + sipDomain,
+        password: creds.password,
+        register: true,
+        register_expires: 300,
+        connection_recovery_min_interval: 4,
+        connection_recovery_max_interval: 30,
+        session_timers: false,
+      });
 
-      await client.connect();
+      ua.on("registered",          () => onStatus("ready"));
+      ua.on("unregistered",        () => onStatus("offline"));
+      ua.on("registrationFailed",  (e) => { console.error("[Voice] reg failed:", e.cause); onStatus("offline"); });
+      ua.on("disconnected",        () => onStatus("offline"));
+      ua.on("newRTCSession",       handleSession);
+      ua.start();
     } catch (e) {
-      console.error("[Voice] init failed", e);
-      status("offline");
+      console.error("[Voice] init failed:", e);
+      cbs.onStatus && cbs.onStatus("offline");
     }
   }
 
-  function handleNotification(n) {
-    if (n.type !== "callUpdate" || !n.call) return;
-    const call = n.call;
-    currentCall = call;
-    switch (call.state) {
-      case "ringing":
-        if (call.direction === "inbound") {
-          callDirection = "in";
-          callNumber = call.options.remoteCallerNumber || call.from || "";
-          cbs.onIncoming && cbs.onIncoming(callNumber);
-        }
-        break;
-      case "active":
-        callStartedAt = Date.now();
-        cbs.onConnected && cbs.onConnected();
-        break;
-      case "hangup":
-      case "destroy":
-        finishCall(call);
-        break;
-    }
+  function wireAudio(pc) {
+    pc.addEventListener("track", (ev) => {
+      const audio = cbs.remoteAudio;
+      if (audio && ev.streams && ev.streams[0]) {
+        audio.srcObject = ev.streams[0];
+        audio.play().catch(() => {});
+      }
+    });
   }
 
-  function finishCall(call) {
+  function handleSession(e) {
+    const session = e.session;
+    if (currentSession) {
+      session.terminate({ status_code: 486, reason_phrase: "Busy Here" });
+      return;
+    }
+    currentSession = session;
+
+    if (session.direction === "incoming") {
+      callDirection = "in";
+      const uri = session.remote_identity && session.remote_identity.uri;
+      callNumber = uri ? (uri.user || "") : "";
+      if (callNumber && !callNumber.startsWith("+")) callNumber = "+" + callNumber;
+      cbs.onIncoming && cbs.onIncoming(callNumber);
+    }
+
+    session.on("peerconnection", (data) => wireAudio(data.peerconnection));
+    session.on("accepted",  () => { if (!callStartedAt) { callStartedAt = Date.now(); cbs.onConnected && cbs.onConnected(); } });
+    session.on("confirmed", () => { if (!callStartedAt) { callStartedAt = Date.now(); cbs.onConnected && cbs.onConnected(); } });
+    session.on("failed",    () => finishCall());
+    session.on("ended",     () => finishCall());
+  }
+
+  function finishCall() {
     const duration = callStartedAt ? Math.round((Date.now() - callStartedAt) / 1000) : 0;
-    const number = callNumber || (call && call.options && (call.options.destinationNumber || call.options.remoteCallerNumber)) || "";
+    const number = callNumber || "";
     if (number && window.API) {
-      const status = duration > 0 ? "completed" : (callDirection === "in" ? "missed" : "no-answer");
-      window.API.logCall({ number, direction: callDirection, status, duration }).catch(() => {});
+      const st = duration > 0 ? "completed" : (callDirection === "in" ? "missed" : "no-answer");
+      window.API.logCall({ number, direction: callDirection, status: st, duration }).catch(() => {});
     }
-    callStartedAt = 0; callNumber = ""; muted = false; currentCall = null;
+    callStartedAt = 0; callNumber = ""; muted = false; currentSession = null;
     cbs.onEnded && cbs.onEnded();
   }
 
-  function status(s) { cbs.onStatus && cbs.onStatus(s); }
-
   // ---- public API ----
   function call(number) {
-    if (!client) throw new Error("Phone not connected");
+    if (!ua || !ua.isRegistered()) throw new Error("Phone not connected");
+    if (currentSession) throw new Error("Already in a call");
     callDirection = "out";
     callNumber = number;
-    currentCall = client.newCall({
-      destinationNumber: number,
-      callerNumber: cbs.myNumber,
-      audio: true,
-      video: false,
+    const target = "sip:" + number.replace(/[^+\d]/g, "") + "@" + sipDomain;
+    ua.call(target, {
+      mediaConstraints: { audio: true, video: false },
+      rtcOfferConstraints: { offerToReceiveAudio: 1, offerToReceiveVideo: 0 },
     });
   }
-  function answer() { if (currentCall) currentCall.answer(); }
-  function hangup() { if (currentCall) currentCall.hangup(); else cbs.onEnded && cbs.onEnded(); }
+
+  function answer() {
+    if (currentSession && currentSession.direction === "incoming") {
+      currentSession.answer({ mediaConstraints: { audio: true, video: false } });
+    }
+  }
+
+  function hangup() {
+    if (currentSession) {
+      try { currentSession.terminate(); } catch (_) {}
+    } else {
+      cbs.onEnded && cbs.onEnded();
+    }
+  }
+
   function toggleMute() {
-    if (!currentCall) return muted;
+    if (!currentSession) return muted;
     muted = !muted;
-    muted ? currentCall.muteAudio() : currentCall.unmuteAudio();
+    if (muted) currentSession.mute({ audio: true });
+    else currentSession.unmute({ audio: true });
     return muted;
   }
-  function toggleSpeaker() { speaker = !speaker; return speaker; }
-  function sendDigit(d) { if (currentCall && currentCall.dtmf) currentCall.dtmf(d); }
-  function inCall() { return !!currentCall; }
+
+  function toggleSpeaker() { return true; }
+  function sendDigit(d) { if (currentSession) currentSession.sendDTMF(d); }
+  function inCall() { return !!currentSession; }
 
   return { init, call, answer, hangup, toggleMute, toggleSpeaker, sendDigit, inCall };
 })();

--- a/phone/voice.js
+++ b/phone/voice.js
@@ -1,139 +1,149 @@
-// Linear Phone — WebRTC voice module (SIP-over-WebSocket via JsSIP)
-// Registers the browser as the "ipad1" SIP endpoint on SignalWire.
-// Inbound PSTN calls reach the browser via <Dial><Sip>sip:ipad1@domain</Sip></Dial> in the IVR.
+// Linear Phone — WebRTC voice module (SignalWire Call Fabric, @signalwire/js v4)
+// The browser logs in as a Call Fabric "Subscriber" with a short-lived token
+// (no SIP registration), so it can both place and receive PSTN calls over
+// WebSocket. Inbound calls reach it via SWML `connect` to /private/<subscriber>.
 window.Voice = (function () {
-  let ua = null;
-  let sipDomain = "";
-  let currentSession = null;
+  let client = null;
+  let rootEl = null;
+  let currentCall = null;   // active Call object
+  let pendingInvite = null; // incoming invite awaiting answer
   let cbs = {};
   let muted = false;
   let callStartedAt = 0;
   let callNumber = "";
   let callDirection = "out";
 
+  function getSDK() {
+    // CDN build exposes window.SignalWire.SignalWire(...)
+    if (window.SignalWire && window.SignalWire.SignalWire) return window.SignalWire.SignalWire;
+    if (typeof window.SignalWire === "function") return window.SignalWire;
+    return null;
+  }
+
+  // Call objects across SDK builds expose slightly different method names;
+  // call the first one that exists so we don't break on minor version drift.
+  function invoke(obj, names, args) {
+    for (const n of names) {
+      if (obj && typeof obj[n] === "function") { try { return obj[n].apply(obj, args || []); } catch (_) {} }
+    }
+  }
+
   async function init(options) {
     cbs = options || {};
+    rootEl = cbs.rootElement || cbs.remoteAudio || null;
     const onStatus = (s) => cbs.onStatus && cbs.onStatus(s);
-    if (!window.JsSIP) {
-      console.warn("[Voice] JsSIP not loaded — calling disabled.");
-      onStatus("offline");
-      return;
-    }
+    const onError = (m) => { console.warn("[Voice]", m); cbs.onError && cbs.onError(m); };
+
+    const SignalWire = getSDK();
+    if (!SignalWire) { onError("Calling SDK not loaded."); onStatus("offline"); return; }
     onStatus("connecting");
     try {
-      const creds = await cbs.getSipCreds();
-      if (!creds || !creds.domain || !creds.user || !creds.password) {
-        throw new Error("SIP credentials not configured (WEBPHONE_SIP_USER/DOMAIN/WEBRTC_PASSWORD)");
-      }
-      sipDomain = creds.domain;
-      JsSIP.debug.disable("JsSIP:*");
+      const { token } = await cbs.getRtcToken();
+      if (!token) throw new Error("No token returned (check SignalWire project/token + Subscriber).");
 
-      const socket = new JsSIP.WebSocketInterface("wss://" + sipDomain);
-      ua = new JsSIP.UA({
-        sockets: [socket],
-        uri: "sip:" + creds.user + "@" + sipDomain,
-        password: creds.password,
-        register: true,
-        register_expires: 300,
-        connection_recovery_min_interval: 4,
-        connection_recovery_max_interval: 30,
-        session_timers: false,
+      client = await SignalWire({ token });
+
+      // Go online to receive inbound call invites.
+      await client.online({
+        incomingCallHandlers: {
+          all: (notification) => handleInvite(notification),
+        },
       });
-
-      ua.on("registered",          () => onStatus("ready"));
-      ua.on("unregistered",        () => onStatus("offline"));
-      ua.on("registrationFailed",  (e) => { console.error("[Voice] reg failed:", e.cause); onStatus("offline"); });
-      ua.on("disconnected",        () => onStatus("offline"));
-      ua.on("newRTCSession",       handleSession);
-      ua.start();
+      onStatus("ready");
     } catch (e) {
-      console.error("[Voice] init failed:", e);
-      cbs.onStatus && cbs.onStatus("offline");
+      onError("Voice connect failed: " + (e && e.message || e));
+      onStatus("offline");
     }
   }
 
-  function wireAudio(pc) {
-    pc.addEventListener("track", (ev) => {
-      const audio = cbs.remoteAudio;
-      if (audio && ev.streams && ev.streams[0]) {
-        audio.srcObject = ev.streams[0];
-        audio.play().catch(() => {});
-      }
-    });
+  function handleInvite(notification) {
+    const invite = (notification && notification.invite) || notification;
+    pendingInvite = invite;
+    const d = (invite && invite.details) || invite || {};
+    callDirection = "in";
+    callNumber = d.callerIdNumber || d.caller_id_number || d.from || "";
+    if (callNumber && !String(callNumber).startsWith("+") && /^\d+$/.test(callNumber)) callNumber = "+" + callNumber;
+    cbs.onIncoming && cbs.onIncoming(callNumber);
   }
 
-  function handleSession(e) {
-    const session = e.session;
-    if (currentSession) {
-      session.terminate({ status_code: 486, reason_phrase: "Busy Here" });
-      return;
+  function attachCall(call) {
+    currentCall = call;
+    const onActive = () => { if (!callStartedAt) { callStartedAt = Date.now(); cbs.onConnected && cbs.onConnected(); } };
+    // Cover the various state event shapes emitted by the SDK.
+    if (call && typeof call.on === "function") {
+      call.on("call.state", (p) => {
+        const st = (p && (p.call_state || p.state)) || "";
+        if (st === "answered" || st === "active") onActive();
+        if (st === "ended" || st === "hangup" || st === "destroy") finishCall();
+      });
+      call.on("active", onActive);
+      call.on("destroy", () => finishCall());
+      call.on("ended", () => finishCall());
     }
-    currentSession = session;
-
-    if (session.direction === "incoming") {
-      callDirection = "in";
-      const uri = session.remote_identity && session.remote_identity.uri;
-      callNumber = uri ? (uri.user || "") : "";
-      if (callNumber && !callNumber.startsWith("+")) callNumber = "+" + callNumber;
-      cbs.onIncoming && cbs.onIncoming(callNumber);
-    }
-
-    session.on("peerconnection", (data) => wireAudio(data.peerconnection));
-    session.on("accepted",  () => { if (!callStartedAt) { callStartedAt = Date.now(); cbs.onConnected && cbs.onConnected(); } });
-    session.on("confirmed", () => { if (!callStartedAt) { callStartedAt = Date.now(); cbs.onConnected && cbs.onConnected(); } });
-    session.on("failed",    () => finishCall());
-    session.on("ended",     () => finishCall());
   }
 
   function finishCall() {
+    if (!currentCall && !callDirection) return;
     const duration = callStartedAt ? Math.round((Date.now() - callStartedAt) / 1000) : 0;
     const number = callNumber || "";
     if (number && window.API) {
       const st = duration > 0 ? "completed" : (callDirection === "in" ? "missed" : "no-answer");
       window.API.logCall({ number, direction: callDirection, status: st, duration }).catch(() => {});
     }
-    callStartedAt = 0; callNumber = ""; muted = false; currentSession = null;
+    callStartedAt = 0; callNumber = ""; muted = false; currentCall = null; pendingInvite = null;
     cbs.onEnded && cbs.onEnded();
   }
 
   // ---- public API ----
-  function call(number) {
-    if (!ua || !ua.isRegistered()) throw new Error("Phone not connected");
-    if (currentSession) throw new Error("Already in a call");
+  async function call(number) {
+    if (!client) throw new Error("Phone not connected");
+    if (currentCall) throw new Error("Already in a call");
     callDirection = "out";
     callNumber = number;
-    const target = "sip:" + number.replace(/[^+\d]/g, "") + "@" + sipDomain;
-    ua.call(target, {
-      mediaConstraints: { audio: true, video: false },
-      rtcOfferConstraints: { offerToReceiveAudio: 1, offerToReceiveVideo: 0 },
-    });
+    try {
+      const c = await client.dial({ to: number, audio: true, video: false, rootElement: rootEl });
+      attachCall(c);
+      await invoke(c, ["start"]);
+    } catch (e) {
+      cbs.onError && cbs.onError("Call failed: " + (e && e.message || e));
+      finishCall();
+    }
   }
 
-  function answer() {
-    if (currentSession && currentSession.direction === "incoming") {
-      currentSession.answer({ mediaConstraints: { audio: true, video: false } });
+  async function answer() {
+    if (!pendingInvite) return;
+    try {
+      const accept = pendingInvite.accept || (pendingInvite.invite && pendingInvite.invite.accept);
+      const target = pendingInvite.accept ? pendingInvite : pendingInvite.invite;
+      const c = await accept.call(target, { rootElement: rootEl, audio: true, video: false });
+      attachCall(c || target);
+    } catch (e) {
+      cbs.onError && cbs.onError("Answer failed: " + (e && e.message || e));
+      finishCall();
     }
   }
 
   function hangup() {
-    if (currentSession) {
-      try { currentSession.terminate(); } catch (_) {}
-    } else {
-      cbs.onEnded && cbs.onEnded();
-    }
+    if (currentCall) { invoke(currentCall, ["hangup", "leave"]); }
+    else if (pendingInvite) {
+      const reject = pendingInvite.reject || (pendingInvite.invite && pendingInvite.invite.reject);
+      const target = pendingInvite.reject ? pendingInvite : pendingInvite.invite;
+      if (reject) try { reject.call(target); } catch (_) {}
+      finishCall();
+    } else { cbs.onEnded && cbs.onEnded(); }
   }
 
   function toggleMute() {
-    if (!currentSession) return muted;
+    if (!currentCall) return muted;
     muted = !muted;
-    if (muted) currentSession.mute({ audio: true });
-    else currentSession.unmute({ audio: true });
+    if (muted) invoke(currentCall, ["audioMute", "muteAudio"]);
+    else invoke(currentCall, ["audioUnmute", "unmuteAudio"]);
     return muted;
   }
 
   function toggleSpeaker() { return true; }
-  function sendDigit(d) { if (currentSession) currentSession.sendDTMF(d); }
-  function inCall() { return !!currentSession; }
+  function sendDigit(d) { if (currentCall) invoke(currentCall, ["sendDigits", "dtmf"], [d]); }
+  function inCall() { return !!(currentCall || pendingInvite); }
 
   return { init, call, answer, hangup, toggleMute, toggleSpeaker, sendDigit, inCall };
 })();

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -358,14 +358,36 @@ function swBase(env) {
 
 // Mint a Call Fabric Subscriber Access Token (SAT) for the browser SDK.
 // The browser registers as this Subscriber and can both place and RECEIVE calls.
-// The same `reference` is what the SWML `connect` targets at /private/<reference>.
-async function mintRtcToken(env) {
-  const reference = env.SUBSCRIBER_REFERENCE || "linearphone";
-  const res = await fetch(`${swBase(env)}/api/fabric/subscribers/tokens`, {
+// If the Subscriber doesn't exist yet we create it automatically (so there's no
+// manual dashboard step). The same identity is what SWML `connect` rings at
+// /private/<reference>.
+function subscriberEmail(env) {
+  const ref = env.SUBSCRIBER_REFERENCE || "linearphone";
+  if (env.SUBSCRIBER_EMAIL) return env.SUBSCRIBER_EMAIL;
+  return ref.includes("@") ? ref : `${ref}@linearit.co`;
+}
+
+async function mintSubscriberToken(env, reference) {
+  return fetch(`${swBase(env)}/api/fabric/subscribers/tokens`, {
     method: "POST",
     headers: { Authorization: swAuth(env), "Content-Type": "application/json" },
     body: JSON.stringify({ reference }),
   });
+}
+
+async function mintRtcToken(env) {
+  const reference = subscriberEmail(env);
+
+  // Try to mint a token. If the Subscriber doesn't exist yet, create it and retry.
+  let res = await mintSubscriberToken(env, reference);
+  if (!res.ok) {
+    await fetch(`${swBase(env)}/api/fabric/resources/subscribers`, {
+      method: "POST",
+      headers: { Authorization: swAuth(env), "Content-Type": "application/json" },
+      body: JSON.stringify({ email: reference, display_name: "Linear Phone" }),
+    }).catch(() => {});
+    res = await mintSubscriberToken(env, reference);
+  }
   if (!res.ok) return json({ error: `Token mint failed (${res.status}): ${await res.text()}` }, 502);
   const data = await res.json();
   return json({ token: data.token });

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -17,8 +17,10 @@
  * Secrets (app only):
  *   SIGNALWIRE_SPACE, SIGNALWIRE_PROJECT, SIGNALWIRE_TOKEN, SIGNALWIRE_NUMBER,
  *   APP_PASSWORD, AUTH_SECRET, ALLOW_ORIGIN, GOOGLE_VOICE_NUMBER
- *   RELAY_RESOURCE  — name the browser registers as (e.g. "linearphone")
- *                     Must match the <Client> name AND the JWT resource param.
+ *   SUBSCRIBER_REFERENCE — Call Fabric Subscriber name the browser logs in as
+ *                          (e.g. "linearphone"). The SWML handler rings it at
+ *                          /private/<SUBSCRIBER_REFERENCE>. Optional:
+ *                          SUBSCRIBER_ADDRESS to override the full address.
  */
 
 // ===== CONFIGURATION (existing IVR) =====
@@ -76,9 +78,12 @@ export default {
       if (p === "/sms/inbound" && request.method === "POST") return smsInbound(request, env);
       if (p === "/sms/status") return new Response("", { status: 200 });
 
+      // ---------- Inbound voice via SWML (Call Fabric: ring browser → cell) ----------
+      if (p === "/swml/voice" && request.method === "POST") return swmlResponse(swmlVoice(env));
+
       // ---------- Softphone API ----------
-      if (p === "/api/login")     return cors(env, await login(request, env));
-      if (p === "/api/sip-creds") return cors(env, await requireAuth(request, env, () => getSipCreds(env)));
+      if (p === "/api/login")  return cors(env, await login(request, env));
+      if (p === "/api/token")  return cors(env, await requireAuth(request, env, () => mintRtcToken(env)));
       if (p === "/api/threads")     return cors(env, await requireAuth(request, env, () => listThreads(env)));
       if (p === "/api/thread")      return cors(env, await requireAuth(request, env, () => getThread(env, url)));
       if (p === "/api/thread/read") return cors(env, await requireAuth(request, env, () => markRead(request, env)));
@@ -142,10 +147,9 @@ function routeDigits(digits, url, env) {
   if (!digits || digits === "1" || digits === "2" || digits === "3") {
     if (inHours) {
       const msg = { "1": "Connecting support.", "2": "Connecting sales.", "3": "Connecting billing." }[digits] || "Please hold while we connect your call.";
-      return dialBrowserFirst(msg, env, url);
+      return dialCellWithGreeting(msg, env, url);
     }
-    // After hours: try browser silently, then Google Voice, then voicemail
-    return dialBrowserFirst("Thank you for holding. We will be right with you.", env, url);
+    return dialCellWithGreeting("Thank you for holding. We will be right with you.", env, url);
   }
 
   return `<?xml version="1.0" encoding="UTF-8"?>
@@ -155,19 +159,16 @@ function routeDigits(digits, url, env) {
 </Response>`;
 }
 
-// Step 1: ring the browser SIP endpoint (18s). If no answer → /ivr/cell-fallback
-// SignalWire cXML uses <Sip>, not <Client> (which is Twilio-only).
-function dialBrowserFirst(message, env, url) {
-  const sipUser = env.WEBPHONE_SIP_USER || "ipad1";
-  const sipDomain = env.WEBPHONE_SIP_DOMAIN || "";
-  const fallback = xmlEscape(new URL("/ivr/cell-fallback", url.origin).toString());
-  if (!sipDomain) return dialCell(env, url); // skip to cell if SIP not configured
-  const sipUri = xmlEscape(`sip:${sipUser}@${sipDomain}`);
+// cXML fallback path (used only if the number still points at /ivr instead of
+// the SWML handler): greet, then ring Google Voice (which has its own voicemail).
+function dialCellWithGreeting(message, env, url) {
+  const cell = env.GOOGLE_VOICE_NUMBER || CELL_NUMBER;
+  const vm = xmlEscape(new URL("/ivr/vm", url.origin).toString());
   return `<?xml version="1.0" encoding="UTF-8"?>
 <Response>
   ${saySsml(message)}
-  <Dial timeout="18" action="${fallback}" method="POST" answerOnBridge="true">
-    <Sip>${sipUri}</Sip>
+  <Dial timeout="25" action="${vm}" method="POST" answerOnBridge="true" callerId="${xmlEscape(env.SIGNALWIRE_NUMBER || "")}">
+    <Number>${xmlEscape(cell)}</Number>
   </Dial>
 </Response>`;
 }
@@ -182,6 +183,46 @@ function dialCell(env, url) {
     <Number>${xmlEscape(cell)}</Number>
   </Dial>
 </Response>`;
+}
+
+/* ============================================================
+ * SWML inbound handler (Call Fabric) — the browser-ringing path
+ * ------------------------------------------------------------
+ * Point the SignalWire number at this URL:
+ *   Phone Number → Handle calls using → "a SWML Script"
+ *     → check "Use External URL for SWML Script handler?"
+ *     → URL: https://<worker>/swml/voice  (POST)
+ *
+ * Flow: greeting → connect serially to the browser Subscriber (18s),
+ * then to Google Voice (25s, which has its own voicemail). No fragile
+ * recording step — Google Voice handles the voicemail.
+ * ============================================================ */
+function swmlVoice(env) {
+  const inHours = isBusinessHoursNow();
+  const greeting = inHours
+    ? "Thank you for calling Linear Tech. Please hold while we connect you."
+    : "Thank you for calling Linear Tech. Our office is currently closed. Please hold while we try to reach someone, or leave a message after the tone.";
+  const reference = env.SUBSCRIBER_REFERENCE || "linearphone";
+  const subscriber = env.SUBSCRIBER_ADDRESS || ("/private/" + reference);
+  const cell = env.GOOGLE_VOICE_NUMBER || CELL_NUMBER;
+  const did = env.SIGNALWIRE_NUMBER || "+18456042025";
+
+  return {
+    version: "1.0.0",
+    sections: {
+      main: [
+        { play: { urls: ["say:" + greeting] } },
+        {
+          connect: {
+            serial: [
+              { to: subscriber, timeout: 18 },
+              { to: cell, from: did, timeout: 25 },
+            ],
+          },
+        },
+      ],
+    },
+  };
 }
 
 function renderVmPrompt(url, promptText) {
@@ -220,6 +261,7 @@ function saySsml(text) {
 }
 function normalizeSpeech(text) { return String(text).replace(/\s+/g, " ").trim(); }
 function twimlResponse(xml) { return new Response(xml, { status: 200, headers: { "Content-Type": "text/xml" } }); }
+function swmlResponse(obj) { return new Response(JSON.stringify(obj), { status: 200, headers: { "Content-Type": "application/json" } }); }
 function xmlEscape(str) {
   return String(str).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&apos;");
 }
@@ -314,28 +356,19 @@ function swBase(env) {
   return `https://${host}`;
 }
 
-// Return SIP credentials for the browser JsSIP client (protected by bearer auth).
-async function getSipCreds(env) {
-  return json({
-    user:     env.WEBPHONE_SIP_USER || "ipad1",
-    domain:   env.WEBPHONE_SIP_DOMAIN || "",
-    password: env.WEBRTC_PASSWORD || "",
-  });
-}
-
+// Mint a Call Fabric Subscriber Access Token (SAT) for the browser SDK.
+// The browser registers as this Subscriber and can both place and RECEIVE calls.
+// The same `reference` is what the SWML `connect` targets at /private/<reference>.
 async function mintRtcToken(env) {
-  const body = new URLSearchParams();
-  const resource = env.RELAY_RESOURCE || "linearphone";
-  body.set("resource", resource);
-  body.set("expires_in", "3600");
-  const res = await fetch(`${swBase(env)}/api/relay/rest/jwt`, {
+  const reference = env.SUBSCRIBER_REFERENCE || "linearphone";
+  const res = await fetch(`${swBase(env)}/api/fabric/subscribers/tokens`, {
     method: "POST",
-    headers: { Authorization: swAuth(env), "Content-Type": "application/x-www-form-urlencoded" },
-    body,
+    headers: { Authorization: swAuth(env), "Content-Type": "application/json" },
+    body: JSON.stringify({ reference }),
   });
   if (!res.ok) return json({ error: `Token mint failed (${res.status}): ${await res.text()}` }, 502);
   const data = await res.json();
-  return json({ token: data.jwt_token, project: env.SIGNALWIRE_PROJECT });
+  return json({ token: data.token });
 }
 
 /* ============================================================

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -77,8 +77,8 @@ export default {
       if (p === "/sms/status") return new Response("", { status: 200 });
 
       // ---------- Softphone API ----------
-      if (p === "/api/login")  return cors(env, await login(request, env));
-      if (p === "/api/token")  return cors(env, await requireAuth(request, env, () => mintRtcToken(env)));
+      if (p === "/api/login")     return cors(env, await login(request, env));
+      if (p === "/api/sip-creds") return cors(env, await requireAuth(request, env, () => getSipCreds(env)));
       if (p === "/api/threads")     return cors(env, await requireAuth(request, env, () => listThreads(env)));
       if (p === "/api/thread")      return cors(env, await requireAuth(request, env, () => getThread(env, url)));
       if (p === "/api/thread/read") return cors(env, await requireAuth(request, env, () => markRead(request, env)));
@@ -155,15 +155,19 @@ function routeDigits(digits, url, env) {
 </Response>`;
 }
 
-// Step 1: ring the browser app (18s). If no answer → /ivr/cell-fallback
+// Step 1: ring the browser SIP endpoint (18s). If no answer → /ivr/cell-fallback
+// SignalWire cXML uses <Sip>, not <Client> (which is Twilio-only).
 function dialBrowserFirst(message, env, url) {
-  const resource = env.RELAY_RESOURCE || "linearphone";
+  const sipUser = env.WEBPHONE_SIP_USER || "ipad1";
+  const sipDomain = env.WEBPHONE_SIP_DOMAIN || "";
   const fallback = xmlEscape(new URL("/ivr/cell-fallback", url.origin).toString());
+  if (!sipDomain) return dialCell(env, url); // skip to cell if SIP not configured
+  const sipUri = xmlEscape(`sip:${sipUser}@${sipDomain}`);
   return `<?xml version="1.0" encoding="UTF-8"?>
 <Response>
   ${saySsml(message)}
   <Dial timeout="18" action="${fallback}" method="POST" answerOnBridge="true">
-    <Client>${xmlEscape(resource)}</Client>
+    <Sip>${sipUri}</Sip>
   </Dial>
 </Response>`;
 }
@@ -310,7 +314,15 @@ function swBase(env) {
   return `https://${host}`;
 }
 
-// Mint a RELAY JWT for the browser SDK (short-lived, safe to expose).
+// Return SIP credentials for the browser JsSIP client (protected by bearer auth).
+async function getSipCreds(env) {
+  return json({
+    user:     env.WEBPHONE_SIP_USER || "ipad1",
+    domain:   env.WEBPHONE_SIP_DOMAIN || "",
+    password: env.WEBRTC_PASSWORD || "",
+  });
+}
+
 async function mintRtcToken(env) {
   const body = new URLSearchParams();
   const resource = env.RELAY_RESOURCE || "linearphone";


### PR DESCRIPTION
## What this does

Ships the Linear Phone softphone (texting + in-browser calling) and rebuilds the
inbound-call path so the **browser rings on any device** — no SIP setup.

### Why the change
The earlier approaches didn't work on SignalWire:
- SignalWire cXML has **no `<Client>` verb** (that's Twilio-only) — so the RELAY
  `<Dial><Client>` approach could never ring the browser.
- The `<Sip>` / `ipad1` SIP endpoint has been historically unreliable.

This switches to SignalWire's recommended **Call Fabric** stack: the browser logs
in as a **Subscriber** with a short-lived token over WebSocket (like the app
login), so it can place and receive PSTN calls in any browser.

### Worker (`worker/src/index.js`)
- `/api/token` mints a Call Fabric **Subscriber Access Token**
  (`POST /api/fabric/subscribers/tokens`).
- New `/swml/voice` returns SWML: greeting → `connect` serial to the browser
  Subscriber (`/private/<ref>`, 18s) → Google Voice (25s, which has its own
  voicemail). No fragile SWML recording step.
- cXML `/ivr` kept as a safe fallback; its dial leg now rings Google Voice
  directly (no `<Sip>`/`<Client>` dependency).
- New secret: `SUBSCRIBER_REFERENCE` (default `linearphone`).

### Frontend (`phone/`)
- Loads `@signalwire/js` v4 from `cdn.signalwire.com`; `voice.js` rewritten to use
  `SignalWire({token})` + `client.online({incomingCallHandlers})` (inbound) and
  `client.dial()` (outbound), with defensive method-name handling.
- Errors now surface as an on-screen toast (visible on iPad).

### Setup still required in dashboards (see `phone/DEPLOY.md` step 5)
1. Paste the new Worker code + add `SUBSCRIBER_REFERENCE=linearphone`.
2. Create a **Subscriber** named `linearphone` in SignalWire.
3. Point the number at **SWML Script → External URL** `…/swml/voice`.

> Note: "Offline" in the app will persist until the Subscriber exists and the
> Worker secrets are set — that's the token source the browser logs in with.

https://claude.ai/code/session_0178AobHq5H5WY5tmr5VvnpC

---
_Generated by [Claude Code](https://claude.ai/code/session_0178AobHq5H5WY5tmr5VvnpC)_