### PR TITLE
Fix Linear Phone Offline: pin SignalWire SDK to v3.x

### DIFF
--- a/phone/index.html
+++ b/phone/index.html
@@ -209,8 +209,12 @@
 <!-- toast -->
 <div id="toast" class="hidden fixed top-4 left-1/2 -translate-x-1/2 z-[60] bg-ink text-white text-sm px-4 py-2 rounded-full shadow-lg"></div>
 
-<!-- SignalWire RELAY browser SDK (WebRTC calling). Pinned to the v1 line. -->
-<script src="https://cdn.signalwire.com/@signalwire/js"></script>
+<!-- SignalWire browser SDK (Call Fabric). Pin to v3.x: the unversioned URL now
+     serves v4.0.0, whose `SignalWire` is a class with a new constructor, which
+     breaks the documented `SignalWire.SignalWire({token})` factory this app uses
+     (caused "Cannot call a class constructor without new"). v3.30 has the
+     Call Fabric online()/dial() API. -->
+<script src="https://cdn.signalwire.com/@signalwire/js@3"></script>
 <script src="config.js"></script>
 <script src="api.js"></script>
 <script src="voice.js"></script>


### PR DESCRIPTION
## Problem

The phone app stayed **Offline** with the toast:

> Voice connect failed: Cannot call a class constructor without |new|

## Cause

`phone/index.html` loaded the SDK from the **unversioned** CDN URL
`https://cdn.signalwire.com/@signalwire/js`, which now serves **v4.0.0**. In v4
`SignalWire` is a `class` with a new `(credentialProvider, options)` constructor.
The app (and SignalWire's own Call Fabric docs) use the v3 factory
`await SignalWire.SignalWire({ token })`, so v4 threw the class-constructor error
on connect.

## Fix

Pin to `https://cdn.signalwire.com/@signalwire/js@3` (v3.30.0), which exposes the
factory function and the Call Fabric `client.online()` / `client.dial()` API the
app already uses. One-line change.

https://claude.ai/code/session_0178AobHq5H5WY5tmr5VvnpC

---
_Generated by [Claude Code](https://claude.ai/code/session_0178AobHq5H5WY5tmr5VvnpC)_