### PR TITLE
Dialer: clear number after call ends; tolerate +1 country code

### DIFF
--- a/phone/app.js
+++ b/phone/app.js
@@ -10,12 +10,12 @@
     return d.length === 10 ? `(${d.slice(0,3)}) ${d.slice(3,6)}-${d.slice(6)}` : (n || "");
   };
   const e164 = (n) => {
-    let d = (n || "").replace(/[^\d+]/g, "");
-    if (d.startsWith("+")) return d;
-    d = d.replace(/\D/g, "");
-    if (d.length === 10) return "+1" + d;
-    if (d.length === 11 && d.startsWith("1")) return "+" + d;
-    return "+" + d;
+    // Work purely on digits so a stray "+", spaces, dashes, or a country code the
+    // user typed themselves (e.g. "+1" or "1") all normalize to the same number.
+    let d = String(n || "").replace(/\D/g, "");
+    if (d.length === 11 && d.startsWith("1")) return "+" + d; // 1 + 10-digit US/Canada
+    if (d.length === 10) return "+1" + d;                     // bare 10-digit US number
+    return "+" + d;                                           // already has a country code
   };
   const timeAgo = (iso) => {
     const s = Math.floor((Date.now() - new Date(iso).getTime()) / 1000);
@@ -349,7 +349,11 @@
         $("#callControls").classList.remove("hidden");
         startCallTimer();
       },
-      onEnded: () => { hideCallOverlay(); loadCalls(); },
+      onEnded: () => {
+        hideCallOverlay(); loadCalls();
+        // Clear the dialed number so the pad is fresh for the next call.
+        if (dialInput) { dialInput.value = ""; updateDialMatch(); }
+      },
     });
   }
 


### PR DESCRIPTION
Two small dialer UX tweaks requested after voice calling started working end-to-end.

## 1. Clear the dialed number after a call ends
`onEnded` now resets `#dialInput` (and its contact-match label), so the number you
just called doesn't linger on the keypad into the next call.

## 2. Tolerate a typed country code
`e164()` now normalizes purely from the digits, so `+1 845 604 2025`, `1 845 604
2025`, and `845 604 2025` all resolve to the same `+18456042025` instead of
misdialing when you include `+1` yourself. Genuine international numbers (already
carrying a country code) are preserved.

https://claude.ai/code/session_0178AobHq5H5WY5tmr5VvnpC

---
_Generated by [Claude Code](https://claude.ai/code/session_0178AobHq5H5WY5tmr5VvnpC)_