### PR TITLE
Dialer: stop iPad double-tap-to-zoom on the keypad

### DIFF
--- a/phone/index.html
+++ b/phone/index.html
@@ -25,6 +25,10 @@
     }
     /* 16px inputs prevent iOS Safari from zooming when a field is focused */
     input, textarea, select, button { font-size: 16px; }
+    /* Tapping the same key twice quickly otherwise reads as a double-tap and
+       zooms the page on iPad Safari; this disables that on tappable controls
+       while keeping pinch-zoom and scrolling. */
+    button, .dialkey, a, [role="button"] { touch-action: manipulation; }
     /* comfortable, low-glare surfaces */
     .panel { background: #ffffff; }
     main { background: #f6f7f9; }


### PR DESCRIPTION
## Symptom
Dialing two of the same digit in a row made the screen zoom/jump on iPad — felt sloppy.

## Cause
Two quick taps on the same key location register as a **double-tap**, which iPad
Safari interprets as double-tap-to-zoom.

## Fix
Add `touch-action: manipulation` to buttons / `.dialkey` / links. This disables
double-tap-to-zoom on those controls (and removes the 300ms tap delay) while
pinch-zoom and scrolling still work everywhere.

https://claude.ai/code/session_0178AobHq5H5WY5tmr5VvnpC

---
_Generated by [Claude Code](https://claude.ai/code/session_0178AobHq5H5WY5tmr5VvnpC)_