### PR TITLE
Messages: add "New message" to start a conversation

### DIFF
--- a/phone/app.js
+++ b/phone/app.js
@@ -104,8 +104,27 @@
     } catch (e) { /* offline / not ready */ }
   }
 
+  // Start a brand-new conversation: show the thread view with an editable
+  // "To" field instead of a fixed title.
+  function openCompose() {
+    currentThread = null;
+    $("#threadTitle").classList.add("hidden");
+    $("#threadSub").classList.add("hidden");
+    const to = $("#threadTo");
+    to.classList.remove("hidden");
+    to.value = "";
+    $("#threadMessages").innerHTML = "";
+    $("#threadView").classList.remove("hidden");
+    setTimeout(() => to.focus(), 50);
+  }
+  $("#newMsgBtn").onclick = openCompose;
+
   async function openThread(number) {
     currentThread = number;
+    // leave compose mode: show the fixed title, hide the recipient input
+    $("#threadTo").classList.add("hidden");
+    $("#threadTitle").classList.remove("hidden");
+    $("#threadSub").classList.remove("hidden");
     $("#threadTitle").textContent = displayName(number);
     $("#threadSub").textContent = contactFor(number) ? fmtNumber(number) : "";
     $("#threadView").classList.remove("hidden");
@@ -143,13 +162,20 @@
   $("#composer").addEventListener("submit", async (e) => {
     e.preventDefault();
     const body = composerInput.value.trim();
-    if (!body || !currentThread) return;
+    if (!body) return;
+    // In compose mode there's no current thread yet — use the typed number.
+    let target = currentThread;
+    if (!target) {
+      const raw = $("#threadTo").value.trim();
+      if (!raw) { toast("Enter a phone number first"); $("#threadTo").focus(); return; }
+      target = e164(raw);
+    }
     composerInput.value = ""; composerInput.style.height = "auto";
     // optimistic
     const box = $("#threadMessages");
     box.insertAdjacentHTML("beforeend", `<div class="flex justify-end"><div class="max-w-[78%] px-3 py-2 bg-brand/70 text-white bubble-out"><div class="text-[15px]">${esc(body)}</div></div></div>`);
     box.scrollTop = box.scrollHeight;
-    try { await API.sendSms(currentThread, body); openThread(currentThread); loadThreads(); }
+    try { await API.sendSms(target, body); openThread(target); loadThreads(); }
     catch (err) { toast("Send failed: " + err.message); }
   });
 

--- a/phone/index.html
+++ b/phone/index.html
@@ -91,6 +91,11 @@
 
     <!-- MESSAGES -->
     <section data-panel="messages" class="panel absolute inset-0 flex flex-col">
+      <!-- list header with New Message button -->
+      <div class="border-b px-4 py-3 flex items-center justify-between shrink-0">
+        <div class="font-semibold text-lg">Messages</div>
+        <button id="newMsgBtn" class="bg-brand text-white rounded-full w-9 h-9 grid place-items-center text-2xl leading-none shadow" title="New message">+</button>
+      </div>
       <!-- conversation list -->
       <div id="threadList" class="flex-1 overflow-y-auto noscroll"></div>
       <!-- thread view (slides over) -->
@@ -100,6 +105,8 @@
           <div class="flex-1 min-w-0">
             <div id="threadTitle" class="font-semibold truncate">—</div>
             <div id="threadSub" class="text-[11px] text-slate-500 truncate"></div>
+            <input id="threadTo" inputmode="tel" placeholder="Enter phone number"
+              class="hidden w-full text-[15px] border rounded-lg px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-brand" />
           </div>
           <button id="threadCall" class="px-2 py-1 text-brand" title="Call">📞</button>
         </div>


### PR DESCRIPTION
You could only reply to existing threads — there was no way to start a new text conversation.

## Change
- Adds a **Messages** header with a **+** (New message) button.
- Tapping it opens the thread view with an editable **"Enter phone number"** field instead of a fixed title.
- The composer sends to that typed number (normalized to E.164 via `e164()`), then opens the freshly created thread.
- Opening an existing thread hides the input and restores the normal title, so existing behavior is unchanged.

https://claude.ai/code/session_0178AobHq5H5WY5tmr5VvnpC

---
_Generated by [Claude Code](https://claude.ai/code/session_0178AobHq5H5WY5tmr5VvnpC)_