### PR TITLE
Contacts: self-heal table + .vcf bulk import

### DIFF
--- a/phone/api.js
+++ b/phone/api.js
@@ -50,6 +50,7 @@
     // Contacts
     contacts: () => req("/api/contacts"),
     saveContact: (c) => req("/api/contacts", { method: "POST", body: c }),
+    importContacts: (contacts) => req("/api/contacts/import", { method: "POST", body: { contacts } }),
     deleteContact: (id) => req("/api/contacts/delete", { method: "POST", body: { id } }),
   };
 })();

--- a/phone/app.js
+++ b/phone/app.js
@@ -278,6 +278,47 @@
     catch (e) { toast(e.message); }
   };
 
+  // ---- vCard (.vcf) import ----
+  // Parse a .vcf into [{name, number}]. Handles multiple cards, multiple TEL
+  // lines per card, grouped iOS properties (item1.TEL), and folded lines.
+  function parseVCards(text) {
+    const unfolded = text.replace(/\r\n/g, "\n").replace(/\n[ \t]/g, ""); // unfold continuations
+    const out = [];
+    const cards = unfolded.split(/BEGIN:VCARD/i).slice(1);
+    for (const card of cards) {
+      let fn = "", n = "";
+      const tels = [];
+      for (const line of card.split("\n")) {
+        const colon = line.indexOf(":");
+        if (colon < 0) continue;
+        const key = line.slice(0, colon).toUpperCase();
+        const val = line.slice(colon + 1).trim();
+        if (/(^|\.)FN(;|$)/.test(key)) fn = val;
+        else if (/(^|\.)N(;|$)/.test(key) && !n) n = val.split(";").filter(Boolean).reverse().join(" ").trim();
+        else if (/(^|\.)TEL(;|$)/.test(key) && val) tels.push(val);
+      }
+      const name = (fn || n || "").replace(/\\,/g, ",").trim();
+      for (const t of tels) out.push({ name: name || t, number: t });
+    }
+    return out;
+  }
+
+  $("#contactImport").onclick = () => $("#vcfInput").click();
+  $("#vcfInput").addEventListener("change", async (e) => {
+    const file = e.target.files && e.target.files[0];
+    e.target.value = ""; // allow re-importing the same file later
+    if (!file) return;
+    try {
+      const text = await file.text();
+      const parsed = parseVCards(text);
+      if (!parsed.length) return toast("No contacts found in that file");
+      toast(`Importing ${parsed.length}…`);
+      const { imported } = await API.importContacts(parsed);
+      await loadContacts();
+      toast(`Imported ${imported} contact${imported === 1 ? "" : "s"}`);
+    } catch (err) { toast("Import failed: " + err.message); }
+  });
+
   // ====================================================================
   // DIALER
   // ====================================================================

--- a/phone/index.html
+++ b/phone/index.html
@@ -149,7 +149,9 @@
     <section data-panel="contacts" class="panel hidden absolute inset-0 flex flex-col">
       <div class="p-3 border-b flex gap-2">
         <input id="contactSearch" placeholder="Search contacts" class="flex-1 border rounded-xl px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand" />
+        <button id="contactImport" class="border border-brand text-brand rounded-xl px-3" title="Import .vcf file">Import</button>
         <button id="contactAdd" class="bg-brand text-white rounded-xl px-3">＋</button>
+        <input id="vcfInput" type="file" accept=".vcf,text/vcard" class="hidden" />
       </div>
       <div id="contactList" class="flex-1 overflow-y-auto noscroll divide-y"></div>
     </section>

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -93,6 +93,7 @@ export default {
       if (p === "/api/voicemail")   return cors(env, await requireAuth(request, env, () => listVoicemail(env)));
       if (p === "/api/contacts" && request.method === "GET")  return cors(env, await requireAuth(request, env, () => listContacts(env)));
       if (p === "/api/contacts" && request.method === "POST") return cors(env, await requireAuth(request, env, () => saveContact(request, env)));
+      if (p === "/api/contacts/import" && request.method === "POST") return cors(env, await requireAuth(request, env, () => importContacts(request, env)));
       if (p === "/api/contacts/delete") return cors(env, await requireAuth(request, env, () => deleteContact(request, env)));
 
       return cors(env, json({ error: "Not found" }, 404));
@@ -475,11 +476,24 @@ async function listVoicemail(env) {
 /* ============================================================
  * Contacts
  * ============================================================ */
+// Make sure the contacts table exists (self-heal if the DB was set up before
+// this table was added, which otherwise makes saves/loads fail silently).
+async function ensureContactsTable(env) {
+  await env.DB.prepare(
+    "CREATE TABLE IF NOT EXISTS contacts (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, number TEXT NOT NULL, created_at TEXT NOT NULL DEFAULT (datetime('now')))"
+  ).run();
+  await env.DB.prepare(
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_contacts_number ON contacts(number)"
+  ).run();
+}
+
 async function listContacts(env) {
+  await ensureContactsTable(env);
   const rows = await env.DB.prepare("SELECT id, name, number FROM contacts ORDER BY name ASC").all();
   return json({ contacts: rows.results || [] });
 }
 async function saveContact(request, env) {
+  await ensureContactsTable(env);
   const c = await readForm(request);
   const number = e164(c.number);
   if (!c.name || !number) return json({ error: "name and number required" }, 400);
@@ -492,7 +506,35 @@ async function saveContact(request, env) {
   return json({ ok: true });
 }
 async function deleteContact(request, env) {
+  await ensureContactsTable(env);
   const { id } = await readForm(request);
   await env.DB.prepare("DELETE FROM contacts WHERE id=?").bind(id).run();
   return json({ ok: true });
+}
+// Bulk import (e.g. from a parsed .vcf). Body: { contacts: [{name, number}, ...] }
+async function importContacts(request, env) {
+  await ensureContactsTable(env);
+  const body = await readForm(request);
+  let list = body.contacts;
+  if (typeof list === "string") { try { list = JSON.parse(list); } catch (_) { list = []; } }
+  if (!Array.isArray(list)) return json({ error: "contacts array required" }, 400);
+
+  const stmt = env.DB.prepare(
+    "INSERT INTO contacts (name, number) VALUES (?,?) ON CONFLICT(number) DO UPDATE SET name=excluded.name"
+  );
+  const batch = [];
+  for (const c of list) {
+    const name = ((c && c.name) || "").toString().trim();
+    const number = e164(c && c.number);
+    if (!name || !number || number.length < 8) continue; // skip junk
+    batch.push(stmt.bind(name, number));
+  }
+  if (!batch.length) return json({ imported: 0 });
+  // Chunk to stay within D1 batch limits.
+  let imported = 0;
+  for (let i = 0; i < batch.length; i += 50) {
+    await env.DB.batch(batch.slice(i, i + 50));
+    imported += Math.min(50, batch.length - i);
+  }
+  return json({ imported });
 }


### PR DESCRIPTION
## Two contact problems

1. **Added contacts don't show up** — likely the D1 `contacts` table wasn't created (DB set up before that table was added). The Worker now **self-heals**: every contacts call runs `CREATE TABLE IF NOT EXISTS contacts` (+ unique index), so saves/loads stop failing silently.
2. **No way to import a phone's contacts** — added a `.vcf` import.

## Changes
- **Worker:** `ensureContactsTable()` called in list/save/delete; new `POST /api/contacts/import` that bulk-inserts a parsed list using chunked D1 batches (ON CONFLICT updates by number).
- **Frontend:** "Import" button + hidden file input on the Contacts screen. Client parses the `.vcf` (multiple cards, multiple `TEL` lines per card, folded lines, iOS grouped `item1.TEL` props), normalizes numbers to E.164, and bulk-imports, then refreshes the list.
- **api.js:** `importContacts()`.

> Note: the Worker (`worker/src/index.js`) is deployed by pasting into Cloudflare, so this must be applied there too for the fix + import to work.

https://claude.ai/code/session_0178AobHq5H5WY5tmr5VvnpC

---
_Generated by [Claude Code](https://claude.ai/code/session_0178AobHq5H5WY5tmr5VvnpC)_