### PR TITLE
Fix contacts never rendering (esc crashed on numeric id)

### DIFF
--- a/phone/app.js
+++ b/phone/app.js
@@ -25,7 +25,7 @@
     if (s < 604800) return Math.floor(s/86400) + "d";
     return new Date(iso).toLocaleDateString();
   };
-  const esc = (s) => (s||"").replace(/[&<>"]/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;"}[c]));
+  const esc = (s) => String(s ?? "").replace(/[&<>"]/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;"}[c]));
   const toast = (msg) => {
     const t = $("#toast"); t.textContent = msg; t.classList.remove("hidden");
     clearTimeout(t._h); t._h = setTimeout(() => t.classList.add("hidden"), 2600);


### PR DESCRIPTION
## Symptom
Contacts (including a successful import of 1283) never appeared in the list, even though the API returns them correctly.

## Cause
`esc(c.id)` is called in the contact row template, but `c.id` is a **number**. `esc` was `(s) => (s||"").replace(...)` — for a number, `(s||"")` stays a number and `.replace` doesn't exist, so `renderContacts` threw on the first contact. `loadContacts`'s `catch {}` swallowed the error, so the list silently never updated. (Empty list rendered fine, which is why it always looked like "No contacts.")

## Fix
Coerce in `esc`: `String(s ?? "").replace(...)`. One line; makes `esc` safe for numbers/null and unblocks rendering.

https://claude.ai/code/session_0178AobHq5H5WY5tmr5VvnpC

---
_Generated by [Claude Code](https://claude.ai/code/session_0178AobHq5H5WY5tmr5VvnpC)_