### PR TITLE
Add downloadable Wireshark GUI wrapper for Linux

### DIFF
--- a/wireshark-gui/README.md
+++ b/wireshark-gui/README.md
@@ -1,0 +1,61 @@
+# Wireshark GUI Wrapper
+
+A minimal point-and-click app for capturing and viewing network traffic
+on Linux, without needing to know any command-line syntax. It runs
+`tshark` (Wireshark's capture engine) for you behind a simple window with
+Start/Stop, a filter box, and a live packet table - and a button to open
+the full Wireshark app on the same capture whenever you want to dig deeper.
+
+Everything runs **locally on your own computer**. Nothing is uploaded
+anywhere.
+
+## Requirements
+
+- Linux with Python 3 (comes with Tkinter on most distros)
+- `tshark` (installed with Wireshark, or via `wireshark-common`/`tshark` package)
+- Optional: the full `wireshark` app, for the "Open in Wireshark" button
+
+## Setup
+
+1. Download this folder (or the whole repo) to your Linux computer.
+2. Run the guided setup, which checks for missing packages and asks
+   before installing anything:
+
+   ```bash
+   ./install.sh
+   ```
+
+3. Launch the app:
+
+   ```bash
+   python3 wireshark_gui.py
+   ```
+
+## Capturing without sudo every time
+
+Packet capture normally needs root. To allow your regular user account
+to capture (recommended, instead of running the GUI as root):
+
+```bash
+sudo dpkg-reconfigure wireshark-common   # choose "Yes"
+sudo usermod -aG wireshark $USER
+```
+
+Then log out and back in. `install.sh` prints these same steps.
+
+If you'd rather not set that up, just run the app with `sudo python3
+wireshark_gui.py`.
+
+## Using the app
+
+1. Pick a network interface from the dropdown (e.g. `eth0`, `wlan0`).
+2. Optionally type a filter using normal Wireshark filter syntax, e.g.
+   `tcp.port == 443` or `http`.
+3. Click **Start** to begin capturing; **Stop** to end it.
+4. Use **Save As...** to export the capture as a `.pcapng` file, or
+   **Open in Wireshark** to inspect it in the full Wireshark app.
+
+## Only capture traffic you're authorized to monitor
+
+Use this tool only on networks and devices you own or have explicit
+permission to monitor.

--- a/wireshark-gui/index.html
+++ b/wireshark-gui/index.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Wireshark GUI Wrapper - Download</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            min-height: 100vh;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            padding: 20px;
+        }
+
+        .container {
+            background: white;
+            border-radius: 20px;
+            box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+            padding: 50px 40px;
+            max-width: 700px;
+            width: 100%;
+        }
+
+        h1 {
+            text-align: center;
+            color: #333333;
+            margin-bottom: 15px;
+            font-size: 2.2em;
+        }
+
+        .subtitle {
+            text-align: center;
+            color: #666;
+            margin-bottom: 30px;
+            font-size: 1.05em;
+        }
+
+        .files-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 20px;
+            margin-bottom: 30px;
+        }
+
+        .file-button {
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+            border: none;
+            padding: 20px 30px;
+            border-radius: 12px;
+            font-size: 1.05em;
+            font-weight: 600;
+            cursor: pointer;
+            transition: all 0.3s ease;
+            text-decoration: none;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            box-shadow: 0 4px 15px rgba(102, 126, 234, 0.4);
+        }
+
+        .file-button:hover {
+            transform: translateY(-3px);
+            box-shadow: 0 6px 20px rgba(102, 126, 234, 0.6);
+        }
+
+        .file-button:active {
+            transform: translateY(-1px);
+        }
+
+        .file-button::before {
+            content: "⬇";
+            margin-right: 10px;
+            font-size: 1.2em;
+        }
+
+        .steps {
+            background: #f6f6fa;
+            border-radius: 12px;
+            padding: 20px 25px;
+            margin-bottom: 20px;
+        }
+
+        .steps h2 {
+            font-size: 1.1em;
+            color: #333;
+            margin-bottom: 10px;
+        }
+
+        .steps ol {
+            margin-left: 20px;
+            color: #444;
+            line-height: 1.7;
+        }
+
+        .steps code {
+            background: #e8e8f0;
+            padding: 2px 6px;
+            border-radius: 4px;
+            font-size: 0.9em;
+        }
+
+        .footer-note {
+            text-align: center;
+            color: #999;
+            font-size: 0.85em;
+            margin-top: 20px;
+            padding-top: 15px;
+            border-top: 1px solid #eee;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Wireshark GUI Wrapper</h1>
+        <p class="subtitle">A simple point-and-click app for capturing network traffic on Linux - no command line needed.</p>
+
+        <div class="files-grid">
+            <a href="wireshark_gui.py" class="file-button" download>App (.py)</a>
+            <a href="install.sh" class="file-button" download>Setup script</a>
+            <a href="README.md" class="file-button" download>README</a>
+        </div>
+
+        <div class="steps">
+            <h2>Quick start</h2>
+            <ol>
+                <li>Download all three files above into the same folder on your Linux computer.</li>
+                <li>Open a terminal in that folder and run <code>bash install.sh</code> to check/install what's needed.</li>
+                <li>Launch the app with <code>python3 wireshark_gui.py</code>.</li>
+                <li>Pick a network interface, click <strong>Start</strong>, and watch traffic appear.</li>
+            </ol>
+        </div>
+
+        <div class="footer-note">
+            <p>Runs entirely on your own computer. Only capture traffic you own or are authorized to monitor.</p>
+        </div>
+    </div>
+</body>
+</html>

--- a/wireshark-gui/install.sh
+++ b/wireshark-gui/install.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Guided setup for the Wireshark GUI Wrapper on Debian/Ubuntu-based Linux.
+# This script only *checks* your system and *asks* before installing or
+# changing anything - it will not run sudo commands without your OK.
+set -euo pipefail
+
+echo "== Wireshark GUI Wrapper setup =="
+
+need_install=()
+
+if ! command -v python3 >/dev/null 2>&1; then
+    need_install+=("python3")
+fi
+
+if ! python3 -c "import tkinter" >/dev/null 2>&1; then
+    need_install+=("python3-tk")
+fi
+
+if ! command -v tshark >/dev/null 2>&1; then
+    need_install+=("tshark")
+fi
+
+if ! command -v wireshark >/dev/null 2>&1; then
+    echo "Note: full 'wireshark' app not found (optional, used by 'Open in Wireshark')."
+    need_install+=("wireshark")
+fi
+
+if [ ${#need_install[@]} -gt 0 ]; then
+    echo "Missing packages: ${need_install[*]}"
+    if command -v apt >/dev/null 2>&1; then
+        read -r -p "Install them now with apt? [y/N] " reply
+        if [[ "$reply" =~ ^[Yy]$ ]]; then
+            sudo apt update
+            sudo apt install -y "${need_install[@]}"
+        else
+            echo "Skipping install. Install the packages above manually before running the app."
+        fi
+    else
+        echo "apt not found - please install the packages above using your distro's package manager."
+    fi
+else
+    echo "All required packages are already installed."
+fi
+
+echo
+echo "Capturing packets normally requires root, or your user being in the"
+echo "'wireshark' group with dumpcap permissions set up. To capture without"
+echo "sudo every time, you can run:"
+echo "  sudo dpkg-reconfigure wireshark-common   # choose 'Yes'"
+echo "  sudo usermod -aG wireshark \$USER"
+echo "then log out and back in."
+echo
+echo "Setup check complete. Run the app with:"
+echo "  python3 $(dirname "$0")/wireshark_gui.py"
+echo "(or 'sudo python3 wireshark_gui.py' if you skipped the group setup above)"

--- a/wireshark-gui/wireshark_gui.py
+++ b/wireshark-gui/wireshark_gui.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""Simple point-and-click GUI for capturing and viewing network traffic
+via tshark (Wireshark's command-line engine) - no terminal commands needed.
+
+Run with:  python3 wireshark_gui.py
+"""
+
+import os
+import queue
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+import tkinter as tk
+from tkinter import ttk, messagebox, filedialog
+
+TSHARK = shutil.which("tshark")
+WIRESHARK = shutil.which("wireshark")
+
+# (tshark field name, column header)
+FIELDS = [
+    ("frame.number", "No."),
+    ("frame.time_relative", "Time"),
+    ("ip.src", "Source"),
+    ("ip.dst", "Destination"),
+    ("_ws.col.Protocol", "Protocol"),
+    ("frame.len", "Length"),
+    ("_ws.col.Info", "Info"),
+]
+
+MAX_ROWS = 5000
+
+
+def list_interfaces():
+    """Return a list of (id, description) capture interfaces via `tshark -D`."""
+    if not TSHARK:
+        return []
+    try:
+        out = subprocess.run(
+            [TSHARK, "-D"], capture_output=True, text=True, timeout=10, check=True
+        ).stdout
+    except Exception:
+        return []
+    interfaces = []
+    for line in out.splitlines():
+        line = line.strip()
+        if not line or "." not in line:
+            continue
+        _, rest = line.split(".", 1)
+        rest = rest.strip()
+        name = rest.split(" ", 1)[0]
+        interfaces.append((name, rest))
+    return interfaces
+
+
+class WiresharkGUI(tk.Tk):
+    def __init__(self):
+        super().__init__()
+        self.title("Wireshark GUI Wrapper")
+        self.geometry("1000x600")
+
+        self.proc = None
+        self.reader_thread = None
+        self.line_queue = queue.Queue()
+        self.row_count = 0
+        self.capture_file = os.path.join(
+            tempfile.gettempdir(), "wireshark_gui_capture.pcapng"
+        )
+
+        self._build_ui()
+        self._check_prereqs()
+        self._poll_queue()
+
+    # ---------- UI ----------
+    def _build_ui(self):
+        top = ttk.Frame(self, padding=8)
+        top.pack(side=tk.TOP, fill=tk.X)
+
+        ttk.Label(top, text="Interface:").pack(side=tk.LEFT)
+        self.iface_var = tk.StringVar()
+        self.iface_combo = ttk.Combobox(
+            top, textvariable=self.iface_var, width=30, state="readonly"
+        )
+        self.iface_combo.pack(side=tk.LEFT, padx=(4, 10))
+        self._refresh_interfaces()
+
+        ttk.Button(top, text="Refresh", command=self._refresh_interfaces).pack(
+            side=tk.LEFT, padx=(0, 10)
+        )
+
+        ttk.Label(top, text="Filter:").pack(side=tk.LEFT)
+        self.filter_var = tk.StringVar()
+        filter_entry = ttk.Entry(top, textvariable=self.filter_var, width=30)
+        filter_entry.pack(side=tk.LEFT, padx=(4, 10))
+        filter_entry.insert(0, "e.g. tcp.port == 443")
+
+        self.start_btn = ttk.Button(top, text="Start", command=self.start_capture)
+        self.start_btn.pack(side=tk.LEFT, padx=4)
+        self.stop_btn = ttk.Button(
+            top, text="Stop", command=self.stop_capture, state=tk.DISABLED
+        )
+        self.stop_btn.pack(side=tk.LEFT, padx=4)
+        ttk.Button(top, text="Clear", command=self.clear_list).pack(
+            side=tk.LEFT, padx=4
+        )
+        ttk.Button(top, text="Save As...", command=self.save_as).pack(
+            side=tk.LEFT, padx=4
+        )
+        ttk.Button(
+            top, text="Open in Wireshark", command=self.open_in_wireshark
+        ).pack(side=tk.LEFT, padx=4)
+
+        columns = [c[0] for c in FIELDS]
+        self.tree = ttk.Treeview(self, columns=columns, show="headings")
+        for field, header in FIELDS:
+            self.tree.heading(field, text=header)
+            width = 90 if field in ("frame.number", "frame.len") else 150
+            if field == "_ws.col.Info":
+                width = 350
+            self.tree.column(field, width=width, anchor=tk.W)
+        self.tree.pack(fill=tk.BOTH, expand=True, padx=8, pady=(0, 8))
+
+        vsb = ttk.Scrollbar(self.tree, orient="vertical", command=self.tree.yview)
+        self.tree.configure(yscrollcommand=vsb.set)
+        vsb.pack(side=tk.RIGHT, fill=tk.Y)
+
+        self.status_var = tk.StringVar(value="Ready.")
+        ttk.Label(self, textvariable=self.status_var, anchor=tk.W, padding=4).pack(
+            side=tk.BOTTOM, fill=tk.X
+        )
+
+        self.protocol("WM_DELETE_WINDOW", self._on_close)
+
+    def _check_prereqs(self):
+        if not TSHARK:
+            messagebox.showerror(
+                "tshark not found",
+                "This tool needs Wireshark's 'tshark' command-line engine.\n\n"
+                "Install it first, e.g.:\n"
+                "  sudo apt install wireshark-common tshark\n\n"
+                "See install.sh in this folder for a guided setup.",
+            )
+            self.start_btn.config(state=tk.DISABLED)
+
+    def _refresh_interfaces(self):
+        interfaces = list_interfaces()
+        values = [f"{name} ({desc})" if desc else name for name, desc in interfaces]
+        self.iface_combo["values"] = values
+        if values and not self.iface_var.get():
+            self.iface_combo.current(0)
+
+    # ---------- Capture control ----------
+    def start_capture(self):
+        if self.proc is not None:
+            return
+        if not TSHARK:
+            messagebox.showerror("Missing tshark", "tshark is not installed.")
+            return
+
+        choice = self.iface_var.get()
+        if not choice:
+            messagebox.showwarning("No interface", "Please choose a network interface.")
+            return
+        iface = choice.split(" ", 1)[0]
+
+        display_filter = self.filter_var.get().strip()
+        if display_filter.startswith("e.g."):
+            display_filter = ""
+
+        cmd = [TSHARK, "-i", iface, "-l", "-n", "-P", "-T", "fields"]
+        for field, _ in FIELDS:
+            cmd += ["-e", field]
+        cmd += ["-E", "separator=\t", "-E", "occurrence=f"]
+        if display_filter:
+            cmd += ["-Y", display_filter]
+        cmd += ["-w", self.capture_file]
+
+        try:
+            self.proc = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                bufsize=1,
+            )
+        except Exception as exc:
+            messagebox.showerror("Failed to start capture", str(exc))
+            self.proc = None
+            return
+
+        self.reader_thread = threading.Thread(target=self._read_output, daemon=True)
+        self.reader_thread.start()
+
+        self.start_btn.config(state=tk.DISABLED)
+        self.stop_btn.config(state=tk.NORMAL)
+        self.status_var.set(f"Capturing on {iface}...")
+
+    def stop_capture(self):
+        if self.proc is None:
+            return
+        try:
+            self.proc.terminate()
+            self.proc.wait(timeout=5)
+        except Exception:
+            try:
+                self.proc.kill()
+            except Exception:
+                pass
+        self.proc = None
+        self.start_btn.config(state=tk.NORMAL)
+        self.stop_btn.config(state=tk.DISABLED)
+        self.status_var.set(f"Stopped. {self.row_count} packets captured.")
+
+    def _read_output(self):
+        proc = self.proc
+        if proc is None or proc.stdout is None:
+            return
+        for line in proc.stdout:
+            self.line_queue.put(line.rstrip("\n"))
+        if proc.stderr is not None:
+            err = proc.stderr.read()
+            if err and "Capturing on" not in err:
+                self.line_queue.put(f"__ERROR__{err.strip()}")
+
+    def _poll_queue(self):
+        try:
+            while True:
+                line = self.line_queue.get_nowait()
+                if line.startswith("__ERROR__"):
+                    self.status_var.set(line[len("__ERROR__") :][:200])
+                    continue
+                self._add_row(line)
+        except queue.Empty:
+            pass
+        self.after(150, self._poll_queue)
+
+    def _add_row(self, line):
+        parts = line.split("\t")
+        if len(parts) < len(FIELDS):
+            parts += [""] * (len(FIELDS) - len(parts))
+        self.tree.insert("", tk.END, values=parts)
+        self.row_count += 1
+        if self.row_count % 20 == 0:
+            self.status_var.set(f"Capturing... {self.row_count} packets")
+        children = self.tree.get_children()
+        if len(children) > MAX_ROWS:
+            for old in children[: len(children) - MAX_ROWS]:
+                self.tree.delete(old)
+
+    def clear_list(self):
+        for item in self.tree.get_children():
+            self.tree.delete(item)
+        self.row_count = 0
+        self.status_var.set("Cleared.")
+
+    # ---------- File actions ----------
+    def save_as(self):
+        if not os.path.exists(self.capture_file):
+            messagebox.showinfo("No capture", "Start and stop a capture first.")
+            return
+        dest = filedialog.asksaveasfilename(
+            defaultextension=".pcapng",
+            filetypes=[("Wireshark capture", "*.pcapng"), ("All files", "*.*")],
+        )
+        if dest:
+            shutil.copy(self.capture_file, dest)
+            self.status_var.set(f"Saved to {dest}")
+
+    def open_in_wireshark(self):
+        if not os.path.exists(self.capture_file):
+            messagebox.showinfo("No capture", "Start and stop a capture first.")
+            return
+        if not WIRESHARK:
+            messagebox.showerror(
+                "Wireshark not found",
+                "The full Wireshark app isn't installed.\n"
+                "Install it with: sudo apt install wireshark",
+            )
+            return
+        subprocess.Popen([WIRESHARK, self.capture_file])
+
+    def _on_close(self):
+        self.stop_capture()
+        self.destroy()
+
+
+def main():
+    if sys.platform not in ("linux", "linux2"):
+        print("This tool is designed for Linux.")
+    app = WiresharkGUI()
+    app.mainloop()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds a new `wireshark-gui/` folder with a local Tkinter app (`wireshark_gui.py`) that wraps `tshark` so users can capture and view network traffic with Start/Stop, a filter box, and a live packet table — no command-line knowledge needed. It also has "Save As" and "Open in Wireshark" buttons for deeper inspection.
- Adds `install.sh`, a guided setup script that checks for `tshark`/`python3-tk`/the full `wireshark` app and asks before installing anything via `apt`.
- Adds `README.md` with setup/usage instructions and notes on capturing without `sudo`.
- Adds `index.html`, a download landing page styled to match the existing `filter/index.html`, so the tool is downloadable from the site once merged (e.g. `wireshark-gui/`).

No existing files were modified — this is purely additive.

## Test plan
- [x] `python3 -m py_compile wireshark_gui.py` passes
- [x] `bash -n install.sh` passes
- [ ] Manual smoke test on a real Linux desktop with a display, `tshark`, and Tkinter installed (not available in this sandbox) — start/stop a capture, apply a filter, save a `.pcapng`, open in full Wireshark


---
_Generated by [Claude Code](https://claude.ai/code/session_0148LbaojJ7L8vbJnD4W8CW3)_