### PR TITLE
Restyle Wireshark GUI download page and expand usage instructions

### DIFF
--- a/wireshark-gui/index.html
+++ b/wireshark-gui/index.html
@@ -12,136 +12,256 @@
         }
 
         body {
-            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            font-family: 'Consolas', 'Menlo', 'Courier New', monospace;
+            background: #0b0f14;
+            background-image:
+                linear-gradient(rgba(0, 255, 155, 0.04) 1px, transparent 1px),
+                linear-gradient(90deg, rgba(0, 255, 155, 0.04) 1px, transparent 1px);
+            background-size: 28px 28px;
+            color: #c9d1d9;
             min-height: 100vh;
             display: flex;
             justify-content: center;
-            align-items: center;
-            padding: 20px;
+            padding: 40px 20px;
         }
 
         .container {
-            background: white;
-            border-radius: 20px;
-            box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
-            padding: 50px 40px;
-            max-width: 700px;
+            background: #10161d;
+            border: 1px solid #1f2a35;
+            border-radius: 10px;
+            box-shadow: 0 0 40px rgba(0, 255, 155, 0.08), 0 20px 60px rgba(0, 0, 0, 0.5);
+            max-width: 780px;
             width: 100%;
+            overflow: hidden;
+        }
+
+        .titlebar {
+            background: #161d26;
+            border-bottom: 1px solid #1f2a35;
+            padding: 12px 16px;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .dot {
+            width: 12px;
+            height: 12px;
+            border-radius: 50%;
+            display: inline-block;
+        }
+        .dot.red { background: #ff5f56; }
+        .dot.yellow { background: #ffbd2e; }
+        .dot.green { background: #27c93f; }
+
+        .titlebar-label {
+            margin-left: 10px;
+            color: #5f6b78;
+            font-size: 0.85em;
+        }
+
+        .content {
+            padding: 40px;
         }
 
         h1 {
-            text-align: center;
-            color: #333333;
-            margin-bottom: 15px;
-            font-size: 2.2em;
+            color: #39ff9c;
+            font-size: 1.8em;
+            margin-bottom: 8px;
+            letter-spacing: 0.5px;
+        }
+
+        h1::before {
+            content: "$ ";
+            color: #5f6b78;
         }
 
         .subtitle {
-            text-align: center;
-            color: #666;
+            color: #8b98a5;
             margin-bottom: 30px;
-            font-size: 1.05em;
+            font-size: 0.95em;
+            line-height: 1.6;
+            border-left: 2px solid #1f2a35;
+            padding-left: 14px;
+        }
+
+        h2 {
+            color: #39ff9c;
+            font-size: 1em;
+            margin: 30px 0 14px;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+        }
+
+        h2::before {
+            content: "// ";
+            color: #5f6b78;
         }
 
         .files-grid {
             display: grid;
             grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-            gap: 20px;
-            margin-bottom: 30px;
+            gap: 14px;
+            margin-bottom: 10px;
         }
 
         .file-button {
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-            color: white;
-            border: none;
-            padding: 20px 30px;
-            border-radius: 12px;
-            font-size: 1.05em;
+            background: #0b0f14;
+            color: #39ff9c;
+            border: 1px solid #2a3b47;
+            padding: 16px 20px;
+            border-radius: 6px;
+            font-size: 0.95em;
             font-weight: 600;
             cursor: pointer;
-            transition: all 0.3s ease;
+            transition: all 0.2s ease;
             text-decoration: none;
             display: flex;
             align-items: center;
             justify-content: center;
-            box-shadow: 0 4px 15px rgba(102, 126, 234, 0.4);
+            font-family: inherit;
         }
 
         .file-button:hover {
-            transform: translateY(-3px);
-            box-shadow: 0 6px 20px rgba(102, 126, 234, 0.6);
-        }
-
-        .file-button:active {
-            transform: translateY(-1px);
+            background: #142019;
+            border-color: #39ff9c;
+            box-shadow: 0 0 15px rgba(57, 255, 156, 0.25);
         }
 
         .file-button::before {
-            content: "⬇";
-            margin-right: 10px;
-            font-size: 1.2em;
+            content: "\2b07";
+            margin-right: 8px;
         }
 
-        .steps {
-            background: #f6f6fa;
-            border-radius: 12px;
-            padding: 20px 25px;
+        .file-desc {
+            color: #5f6b78;
+            font-size: 0.8em;
+            margin-top: 10px;
             margin-bottom: 20px;
         }
 
-        .steps h2 {
-            font-size: 1.1em;
-            color: #333;
-            margin-bottom: 10px;
+        pre {
+            background: #0b0f14;
+            border: 1px solid #1f2a35;
+            border-radius: 6px;
+            padding: 14px 18px;
+            overflow-x: auto;
+            color: #39ff9c;
+            font-size: 0.88em;
+            margin: 10px 0 4px;
         }
 
-        .steps ol {
-            margin-left: 20px;
-            color: #444;
-            line-height: 1.7;
-        }
-
-        .steps code {
-            background: #e8e8f0;
+        code {
+            background: #1a232c;
+            color: #39ff9c;
             padding: 2px 6px;
             border-radius: 4px;
             font-size: 0.9em;
         }
 
-        .footer-note {
-            text-align: center;
-            color: #999;
+        pre code {
+            background: none;
+            padding: 0;
+        }
+
+        ol, ul {
+            margin-left: 22px;
+            color: #c9d1d9;
+            line-height: 1.8;
+            font-size: 0.92em;
+        }
+
+        ul.no-bullets {
+            list-style: none;
+            margin-left: 0;
+        }
+
+        ul.no-bullets li {
+            padding: 8px 0 8px 14px;
+            border-left: 2px solid #1f2a35;
+            margin-bottom: 8px;
+        }
+
+        ul.no-bullets li strong {
+            color: #39ff9c;
+        }
+
+        .note {
+            background: #1a1410;
+            border: 1px solid #4a3a1a;
+            border-radius: 6px;
+            padding: 12px 16px;
+            color: #d8b45a;
             font-size: 0.85em;
             margin-top: 20px;
-            padding-top: 15px;
-            border-top: 1px solid #eee;
+        }
+
+        .note::before {
+            content: "\26a0 ";
+        }
+
+        .footer-note {
+            text-align: center;
+            color: #5f6b78;
+            font-size: 0.8em;
+            margin-top: 30px;
+            padding-top: 20px;
+            border-top: 1px solid #1f2a35;
         }
     </style>
 </head>
 <body>
     <div class="container">
-        <h1>Wireshark GUI Wrapper</h1>
-        <p class="subtitle">A simple point-and-click app for capturing network traffic on Linux - no command line needed.</p>
-
-        <div class="files-grid">
-            <a href="wireshark_gui.py" class="file-button" download>App (.py)</a>
-            <a href="install.sh" class="file-button" download>Setup script</a>
-            <a href="README.md" class="file-button" download>README</a>
+        <div class="titlebar">
+            <span class="dot red"></span>
+            <span class="dot yellow"></span>
+            <span class="dot green"></span>
+            <span class="titlebar-label">root@linux:~/wireshark-gui</span>
         </div>
+        <div class="content">
+            <h1>Wireshark GUI Wrapper</h1>
+            <p class="subtitle">A point-and-click packet capture tool for Linux. It runs <code>tshark</code> (Wireshark's capture engine) behind a simple window with Start/Stop, a filter box, and a live packet table - no terminal commands to memorize.</p>
 
-        <div class="steps">
-            <h2>Quick start</h2>
+            <h2>Download</h2>
+            <div class="files-grid">
+                <a href="wireshark_gui.py" class="file-button" download>wireshark_gui.py</a>
+                <a href="install.sh" class="file-button" download>install.sh</a>
+                <a href="README.md" class="file-button" download>README.md</a>
+            </div>
+            <p class="file-desc">Save all three files into the same folder on your Linux machine.</p>
+
+            <h2>Setup</h2>
             <ol>
-                <li>Download all three files above into the same folder on your Linux computer.</li>
-                <li>Open a terminal in that folder and run <code>bash install.sh</code> to check/install what's needed.</li>
-                <li>Launch the app with <code>python3 wireshark_gui.py</code>.</li>
-                <li>Pick a network interface, click <strong>Start</strong>, and watch traffic appear.</li>
+                <li>Open a terminal in the folder where you saved the files.</li>
+                <li>Run the guided setup script - it checks for missing packages and asks before installing anything:
+                    <pre><code>bash install.sh</code></pre>
+                </li>
+                <li>Launch the app:
+                    <pre><code>python3 wireshark_gui.py</code></pre>
+                </li>
             </ol>
-        </div>
 
-        <div class="footer-note">
-            <p>Runs entirely on your own computer. Only capture traffic you own or are authorized to monitor.</p>
+            <h2>How to use it</h2>
+            <ul class="no-bullets">
+                <li><strong>Interface</strong> — the dropdown at the top lists your network interfaces (e.g. <code>eth0</code>, <code>wlan0</code>). Pick the one you want to monitor, or hit <strong>Refresh</strong> if it just changed.</li>
+                <li><strong>Filter</strong> — type a normal Wireshark display filter here to narrow what you see, e.g. <code>tcp.port == 443</code>, <code>http</code>, or <code>ip.addr == 192.168.1.10</code>. Leave it blank to capture everything.</li>
+                <li><strong>Start / Stop</strong> — begins or ends the capture. Packets appear live in the table below as they're seen: number, time, source, destination, protocol, length, and info.</li>
+                <li><strong>Clear</strong> — empties the table on screen (doesn't affect a running capture).</li>
+                <li><strong>Save As...</strong> — exports the capture to a <code>.pcapng</code> file you can keep or share.</li>
+                <li><strong>Open in Wireshark</strong> — launches the full Wireshark app on the same capture, for deeper inspection than the simple table offers.</li>
+            </ul>
+
+            <h2>Capturing without sudo every time</h2>
+            <p style="color:#c9d1d9; font-size:0.92em; line-height:1.8;">Packet capture normally needs root. To let your regular user account capture instead of running the app as root, run once:</p>
+            <pre><code>sudo dpkg-reconfigure wireshark-common   # choose "Yes"
+sudo usermod -aG wireshark $USER</code></pre>
+            <p style="color:#c9d1d9; font-size:0.92em;">Then log out and back in. Otherwise, just run <code>sudo python3 wireshark_gui.py</code>.</p>
+
+            <div class="note">Only capture traffic on networks and devices you own or have explicit permission to monitor.</div>
+
+            <div class="footer-note">
+                <p>Runs entirely on your own computer. Nothing is uploaded anywhere.</p>
+            </div>
         </div>
     </div>
 </body>


### PR DESCRIPTION
## Summary
- Restyles `wireshark-gui/index.html` from the generic purple-gradient card into a dark, terminal/"IT tool" look (monospace font, terminal window title bar, green accent, faint grid background).
- Expands the on-page content with a full "How to use it" walkthrough covering each control (Interface, Filter, Start/Stop, Clear, Save As, Open in Wireshark) and the no-sudo capture setup steps, in addition to the existing download links and quick setup steps.
- No changes to the Python app (`wireshark_gui.py`) or `install.sh` itself.

## Test plan
- [x] Opened the page locally in a browser to check layout and readability
- [ ] View live on the site after deploy to confirm rendering on GitHub Pages


---
_Generated by [Claude Code](https://claude.ai/code/session_0148LbaojJ7L8vbJnD4W8CW3)_