### PR TITLE
Make Wireshark GUI download page friendlier and less technical

### DIFF
--- a/wireshark-gui/index.html
+++ b/wireshark-gui/index.html
@@ -12,256 +12,251 @@
         }
 
         body {
-            font-family: 'Consolas', 'Menlo', 'Courier New', monospace;
-            background: #0b0f14;
-            background-image:
-                linear-gradient(rgba(0, 255, 155, 0.04) 1px, transparent 1px),
-                linear-gradient(90deg, rgba(0, 255, 155, 0.04) 1px, transparent 1px);
-            background-size: 28px 28px;
-            color: #c9d1d9;
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            background: linear-gradient(135deg, #eef4ff 0%, #f7f0ff 100%);
             min-height: 100vh;
             display: flex;
             justify-content: center;
             padding: 40px 20px;
+            color: #333;
         }
 
         .container {
-            background: #10161d;
-            border: 1px solid #1f2a35;
-            border-radius: 10px;
-            box-shadow: 0 0 40px rgba(0, 255, 155, 0.08), 0 20px 60px rgba(0, 0, 0, 0.5);
-            max-width: 780px;
+            background: white;
+            border-radius: 20px;
+            box-shadow: 0 20px 50px rgba(80, 90, 150, 0.15);
+            padding: 50px 45px;
+            max-width: 760px;
             width: 100%;
-            overflow: hidden;
         }
 
-        .titlebar {
-            background: #161d26;
-            border-bottom: 1px solid #1f2a35;
-            padding: 12px 16px;
-            display: flex;
-            align-items: center;
-            gap: 8px;
-        }
-
-        .dot {
-            width: 12px;
-            height: 12px;
-            border-radius: 50%;
-            display: inline-block;
-        }
-        .dot.red { background: #ff5f56; }
-        .dot.yellow { background: #ffbd2e; }
-        .dot.green { background: #27c93f; }
-
-        .titlebar-label {
-            margin-left: 10px;
-            color: #5f6b78;
-            font-size: 0.85em;
-        }
-
-        .content {
-            padding: 40px;
+        .icon {
+            text-align: center;
+            font-size: 3em;
+            margin-bottom: 10px;
         }
 
         h1 {
-            color: #39ff9c;
-            font-size: 1.8em;
-            margin-bottom: 8px;
-            letter-spacing: 0.5px;
-        }
-
-        h1::before {
-            content: "$ ";
-            color: #5f6b78;
+            text-align: center;
+            color: #333;
+            margin-bottom: 12px;
+            font-size: 2.1em;
         }
 
         .subtitle {
-            color: #8b98a5;
-            margin-bottom: 30px;
-            font-size: 0.95em;
+            text-align: center;
+            color: #667;
+            margin-bottom: 35px;
+            font-size: 1.05em;
             line-height: 1.6;
-            border-left: 2px solid #1f2a35;
-            padding-left: 14px;
+            max-width: 540px;
+            margin-left: auto;
+            margin-right: auto;
         }
 
         h2 {
-            color: #39ff9c;
-            font-size: 1em;
-            margin: 30px 0 14px;
-            text-transform: uppercase;
-            letter-spacing: 1px;
-        }
-
-        h2::before {
-            content: "// ";
-            color: #5f6b78;
+            color: #4d5bce;
+            font-size: 1.2em;
+            margin: 35px 0 16px;
         }
 
         .files-grid {
             display: grid;
             grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-            gap: 14px;
-            margin-bottom: 10px;
+            gap: 16px;
+            margin-bottom: 8px;
         }
 
         .file-button {
-            background: #0b0f14;
-            color: #39ff9c;
-            border: 1px solid #2a3b47;
-            padding: 16px 20px;
-            border-radius: 6px;
-            font-size: 0.95em;
+            background: linear-gradient(135deg, #6d8dff 0%, #8a6ef0 100%);
+            color: white;
+            border: none;
+            padding: 18px 24px;
+            border-radius: 12px;
+            font-size: 1em;
             font-weight: 600;
             cursor: pointer;
-            transition: all 0.2s ease;
+            transition: all 0.25s ease;
             text-decoration: none;
             display: flex;
             align-items: center;
             justify-content: center;
-            font-family: inherit;
+            box-shadow: 0 4px 14px rgba(109, 141, 255, 0.35);
         }
 
         .file-button:hover {
-            background: #142019;
-            border-color: #39ff9c;
-            box-shadow: 0 0 15px rgba(57, 255, 156, 0.25);
+            transform: translateY(-2px);
+            box-shadow: 0 8px 20px rgba(109, 141, 255, 0.5);
         }
 
         .file-button::before {
-            content: "\2b07";
+            content: "⬇";
             margin-right: 8px;
         }
 
-        .file-desc {
-            color: #5f6b78;
-            font-size: 0.8em;
-            margin-top: 10px;
-            margin-bottom: 20px;
+        .file-caption {
+            text-align: center;
+            color: #888;
+            font-size: 0.85em;
+            margin-top: 12px;
+            margin-bottom: 10px;
         }
 
-        pre {
-            background: #0b0f14;
-            border: 1px solid #1f2a35;
-            border-radius: 6px;
-            padding: 14px 18px;
-            overflow-x: auto;
-            color: #39ff9c;
-            font-size: 0.88em;
-            margin: 10px 0 4px;
+        .steps {
+            background: #f6f8ff;
+            border-radius: 14px;
+            padding: 22px 26px;
+        }
+
+        .steps ol {
+            margin-left: 20px;
+            line-height: 2;
+            font-size: 0.98em;
         }
 
         code {
-            background: #1a232c;
-            color: #39ff9c;
-            padding: 2px 6px;
-            border-radius: 4px;
-            font-size: 0.9em;
-        }
-
-        pre code {
-            background: none;
-            padding: 0;
-        }
-
-        ol, ul {
-            margin-left: 22px;
-            color: #c9d1d9;
-            line-height: 1.8;
+            background: #e9edff;
+            color: #4d5bce;
+            padding: 3px 8px;
+            border-radius: 5px;
             font-size: 0.92em;
+            font-family: 'Consolas', 'Courier New', monospace;
         }
 
-        ul.no-bullets {
-            list-style: none;
-            margin-left: 0;
+        .guide-grid {
+            display: grid;
+            grid-template-columns: 1fr;
+            gap: 14px;
         }
 
-        ul.no-bullets li {
-            padding: 8px 0 8px 14px;
-            border-left: 2px solid #1f2a35;
-            margin-bottom: 8px;
+        .guide-card {
+            display: flex;
+            align-items: flex-start;
+            gap: 14px;
+            background: #fbfbff;
+            border: 1px solid #eceffd;
+            border-radius: 12px;
+            padding: 16px 18px;
         }
 
-        ul.no-bullets li strong {
-            color: #39ff9c;
+        .guide-emoji {
+            font-size: 1.5em;
+            line-height: 1;
         }
 
-        .note {
-            background: #1a1410;
-            border: 1px solid #4a3a1a;
-            border-radius: 6px;
-            padding: 12px 16px;
-            color: #d8b45a;
-            font-size: 0.85em;
-            margin-top: 20px;
+        .guide-text strong {
+            display: block;
+            color: #333;
+            margin-bottom: 4px;
         }
 
-        .note::before {
-            content: "\26a0 ";
+        .guide-text span {
+            color: #667;
+            font-size: 0.92em;
+            line-height: 1.5;
+        }
+
+        .tip {
+            background: #eefaf1;
+            border-radius: 12px;
+            padding: 16px 20px;
+            color: #2e7d4f;
+            font-size: 0.92em;
+            margin-top: 30px;
+            line-height: 1.6;
+        }
+
+        .tip strong {
+            display: block;
+            margin-bottom: 4px;
         }
 
         .footer-note {
             text-align: center;
-            color: #5f6b78;
-            font-size: 0.8em;
+            color: #999;
+            font-size: 0.85em;
             margin-top: 30px;
             padding-top: 20px;
-            border-top: 1px solid #1f2a35;
+            border-top: 1px solid #eee;
         }
     </style>
 </head>
 <body>
     <div class="container">
-        <div class="titlebar">
-            <span class="dot red"></span>
-            <span class="dot yellow"></span>
-            <span class="dot green"></span>
-            <span class="titlebar-label">root@linux:~/wireshark-gui</span>
+        <div class="icon">🦈</div>
+        <h1>Wireshark GUI Wrapper</h1>
+        <p class="subtitle">A friendly, easy window for looking at your network traffic on Linux. No typing commands, no technical know-how required - just click and go.</p>
+
+        <div class="files-grid">
+            <a href="wireshark_gui.py" class="file-button" download>Download the App</a>
+            <a href="install.sh" class="file-button" download>Setup Helper</a>
+            <a href="README.md" class="file-button" download>Instructions</a>
         </div>
-        <div class="content">
-            <h1>Wireshark GUI Wrapper</h1>
-            <p class="subtitle">A point-and-click packet capture tool for Linux. It runs <code>tshark</code> (Wireshark's capture engine) behind a simple window with Start/Stop, a filter box, and a live packet table - no terminal commands to memorize.</p>
+        <p class="file-caption">Save all three into the same folder on your computer.</p>
 
-            <h2>Download</h2>
-            <div class="files-grid">
-                <a href="wireshark_gui.py" class="file-button" download>wireshark_gui.py</a>
-                <a href="install.sh" class="file-button" download>install.sh</a>
-                <a href="README.md" class="file-button" download>README.md</a>
-            </div>
-            <p class="file-desc">Save all three files into the same folder on your Linux machine.</p>
-
-            <h2>Setup</h2>
+        <h2>Getting started</h2>
+        <div class="steps">
             <ol>
-                <li>Open a terminal in the folder where you saved the files.</li>
-                <li>Run the guided setup script - it checks for missing packages and asks before installing anything:
-                    <pre><code>bash install.sh</code></pre>
-                </li>
-                <li>Launch the app:
-                    <pre><code>python3 wireshark_gui.py</code></pre>
-                </li>
+                <li>Save the three files above into one folder.</li>
+                <li>Open a terminal in that folder and type: <code>bash install.sh</code> — this checks your computer has everything it needs, and asks before installing anything.</li>
+                <li>Then type: <code>python3 wireshark_gui.py</code> to open the app.</li>
+                <li>A window will appear - you're ready to go!</li>
             </ol>
+        </div>
 
-            <h2>How to use it</h2>
-            <ul class="no-bullets">
-                <li><strong>Interface</strong> — the dropdown at the top lists your network interfaces (e.g. <code>eth0</code>, <code>wlan0</code>). Pick the one you want to monitor, or hit <strong>Refresh</strong> if it just changed.</li>
-                <li><strong>Filter</strong> — type a normal Wireshark display filter here to narrow what you see, e.g. <code>tcp.port == 443</code>, <code>http</code>, or <code>ip.addr == 192.168.1.10</code>. Leave it blank to capture everything.</li>
-                <li><strong>Start / Stop</strong> — begins or ends the capture. Packets appear live in the table below as they're seen: number, time, source, destination, protocol, length, and info.</li>
-                <li><strong>Clear</strong> — empties the table on screen (doesn't affect a running capture).</li>
-                <li><strong>Save As...</strong> — exports the capture to a <code>.pcapng</code> file you can keep or share.</li>
-                <li><strong>Open in Wireshark</strong> — launches the full Wireshark app on the same capture, for deeper inspection than the simple table offers.</li>
-            </ul>
-
-            <h2>Capturing without sudo every time</h2>
-            <p style="color:#c9d1d9; font-size:0.92em; line-height:1.8;">Packet capture normally needs root. To let your regular user account capture instead of running the app as root, run once:</p>
-            <pre><code>sudo dpkg-reconfigure wireshark-common   # choose "Yes"
-sudo usermod -aG wireshark $USER</code></pre>
-            <p style="color:#c9d1d9; font-size:0.92em;">Then log out and back in. Otherwise, just run <code>sudo python3 wireshark_gui.py</code>.</p>
-
-            <div class="note">Only capture traffic on networks and devices you own or have explicit permission to monitor.</div>
-
-            <div class="footer-note">
-                <p>Runs entirely on your own computer. Nothing is uploaded anywhere.</p>
+        <h2>Using the app</h2>
+        <div class="guide-grid">
+            <div class="guide-card">
+                <div class="guide-emoji">🔌</div>
+                <div class="guide-text">
+                    <strong>Interface</strong>
+                    <span>This is just which internet connection to watch (Wi-Fi, wired, etc). Pick one from the dropdown at the top.</span>
+                </div>
             </div>
+            <div class="guide-card">
+                <div class="guide-emoji">🔍</div>
+                <div class="guide-text">
+                    <strong>Filter (optional)</strong>
+                    <span>Want to see only certain traffic? Type something simple like <code>http</code> to see web traffic. Leave it blank to see everything.</span>
+                </div>
+            </div>
+            <div class="guide-card">
+                <div class="guide-emoji">▶️</div>
+                <div class="guide-text">
+                    <strong>Start / Stop</strong>
+                    <span>Click Start to begin watching traffic - it will show up in a list as it happens. Click Stop whenever you're done.</span>
+                </div>
+            </div>
+            <div class="guide-card">
+                <div class="guide-emoji">🧹</div>
+                <div class="guide-text">
+                    <strong>Clear</strong>
+                    <span>Wipes the list on your screen so you can start fresh. It doesn't stop or delete your capture.</span>
+                </div>
+            </div>
+            <div class="guide-card">
+                <div class="guide-emoji">💾</div>
+                <div class="guide-text">
+                    <strong>Save As...</strong>
+                    <span>Saves what you captured as a file you can keep, send, or open later.</span>
+                </div>
+            </div>
+            <div class="guide-card">
+                <div class="guide-emoji">🔬</div>
+                <div class="guide-text">
+                    <strong>Open in Wireshark</strong>
+                    <span>If you need to look closer, this opens your capture in the full Wireshark program for more detail.</span>
+                </div>
+            </div>
+        </div>
+
+        <div class="tip">
+            <strong>💡 Good to know</strong>
+            Watching network traffic usually needs extra permission on Linux. If the app can't start capturing, just run it with <code>sudo python3 wireshark_gui.py</code> instead, or follow the one-time setup notes in the Instructions file so you don't need to do that every time.
+        </div>
+
+        <div class="footer-note">
+            <p>Runs entirely on your own computer - nothing is ever uploaded. Only use this on networks and devices you're allowed to monitor.</p>
         </div>
     </div>
 </body>


### PR DESCRIPTION
## Summary
- Replaces the dark, terminal-style "IT tool" look from the previous update with a warm, friendly design (light background, soft gradient card, rounded buttons) since it read as too intimidating for average, non-technical users.
- Keeps the on-page instructions but rewrites them in plain language with friendly icon cards for each button (Interface, Filter, Start/Stop, Clear, Save As, Open in Wireshark).
- No changes to the Python app (`wireshark_gui.py`) or `install.sh`.

## Test plan
- [ ] View live on the site after deploy to confirm rendering


---
_Generated by [Claude Code](https://claude.ai/code/session_0148LbaojJ7L8vbJnD4W8CW3)_