### PR TITLE
Add Geder filter bypass monitor for NinjaOne fleets

### DIFF
--- a/geder-filter-monitor/README.md
+++ b/geder-filter-monitor/README.md
@@ -1,0 +1,82 @@
+# Geder Filter Bypass Monitor
+
+Alerts you when a managed computer has internet traffic going somewhere
+**other than Geder** - which usually means the filter was removed,
+disabled, or bypassed (by the user, or by malware/an attacker on that
+machine). Built to run fleet-wide through **NinjaOne**.
+
+Instead of full packet capture (which would need Wireshark/Npcap
+installed on every endpoint), this uses each computer's own built-in
+connection list (`Get-NetTCPConnection`, no extra software) and checks
+every public IP it's talking to against a known-good "this is Geder"
+allowlist.
+
+## Files
+
+- **`geder-baseline.ps1`** - run once, manually, on a computer you know
+  is properly filtered. Records the IPs it talks to and saves them as
+  the allowlist.
+- **`geder-monitor.ps1`** - the script you deploy to the whole fleet via
+  NinjaOne. Runs on a schedule, compares live connections to the
+  allowlist, and flags anything unexpected.
+
+## Step 1: Build the allowlist
+
+1. Pick a computer you're confident is correctly running Geder.
+2. Copy `geder-baseline.ps1` to it and run it in an elevated PowerShell
+   window:
+   ```powershell
+   .\geder-baseline.ps1
+   ```
+3. While it runs (5 minutes by default), browse a handful of normal
+   sites so it sees real traffic.
+4. It prints and saves the list of remote IPs it saw
+   (`geder-allowlist.json`).
+
+## Step 2: Configure the monitor script
+
+Open `geder-monitor.ps1` and paste the IPs from step 1 into the
+`$AllowlistIPs` array near the top:
+
+```powershell
+[string[]]$AllowlistIPs = @(
+    "203.0.113.10",
+    "203.0.113.11"
+)
+```
+
+If Geder rotates or adds servers later, re-run the baseline and update
+this list.
+
+## Step 3: Deploy through NinjaOne
+
+1. **Add a Custom Field** (Administration → Devices → Custom Fields):
+   create a text field named `gederBypassDetected`. The script writes a
+   description of what it found there, or clears it when everything's
+   fine.
+2. **Add the script** (Administration → Library → Scripting): upload
+   `geder-monitor.ps1` as a new PowerShell script.
+3. **Schedule it**: create a policy/scheduled task that runs the script
+   on all the managed devices you want watched, every 10-15 minutes.
+4. **Create the alert condition** (Administration → Alerts → Conditions):
+   trigger a NinjaOne alert (which can notify you by email, ticket, etc.
+   depending on how your NinjaOne notifications are set up) when either:
+   - the script result is **Failed** (exit code 1), or
+   - the custom field `gederBypassDetected` is **not empty**
+
+That's it - from then on, if a computer's Geder filter disappears and
+it starts talking to the open internet directly, you'll get notified
+instead of finding out after the fact.
+
+## Notes
+
+- Exit code `1` = suspicious traffic found (alert). Exit code `2` = the
+  script isn't configured yet (no allowlist). Exit code `0` = all clear.
+- Details of what was flagged (remote IP, port, and which process made
+  the connection) are appended to `geder-monitor.log` next to the
+  script on that machine, so you can investigate.
+- This flags *connections*, not content - it can't tell you what was
+  looked at, only that traffic bypassed the expected path. Treat every
+  alert as "go check this computer," not definitive proof of anything.
+- Private/local network traffic (10.x, 192.168.x, etc.) is always
+  ignored - only public internet destinations are checked.

--- a/geder-filter-monitor/geder-baseline.ps1
+++ b/geder-filter-monitor/geder-baseline.ps1
@@ -1,0 +1,69 @@
+<#
+.SYNOPSIS
+    One-time learning run: records the internet destinations a properly
+    filtered computer talks to, so geder-monitor.ps1 can later recognize
+    "normal, filtered" traffic vs. traffic that bypasses the filter.
+
+.DESCRIPTION
+    Run this ONCE, manually, on a computer you are certain is correctly
+    running Geder. It samples active outbound connections over a window
+    (default 5 minutes) and saves every distinct public remote IP seen to
+    a JSON allowlist file.
+
+    Afterwards, open the resulting file and copy the IP list into the
+    $AllowlistIPs array near the top of geder-monitor.ps1 before you
+    deploy that script fleet-wide via NinjaOne.
+
+.PARAMETER DurationSeconds
+    How long to sample for. Longer runs catch more of Geder's IPs
+    (e.g. if it uses several servers). Default 300 (5 minutes) - browse
+    a handful of normal sites while it runs.
+
+.PARAMETER SampleIntervalSeconds
+    How often to snapshot active connections during the run.
+
+.PARAMETER OutFile
+    Where to write the resulting allowlist JSON.
+#>
+
+param(
+    [int]$DurationSeconds = 300,
+    [int]$SampleIntervalSeconds = 5,
+    [string]$OutFile = "$PSScriptRoot\geder-allowlist.json"
+)
+
+function Test-PrivateIP {
+    param([string]$IP)
+    if (-not $IP) { return $true }
+    if ($IP -eq '127.0.0.1' -or $IP -eq '::1' -or $IP -eq '0.0.0.0') { return $true }
+    if ($IP -match '^10\.') { return $true }
+    if ($IP -match '^192\.168\.') { return $true }
+    if ($IP -match '^172\.(1[6-9]|2[0-9]|3[0-1])\.') { return $true }
+    if ($IP -match '^169\.254\.') { return $true }
+    if ($IP -match '^::1$|^fe80:|^fc00:|^fd00:') { return $true }
+    return $false
+}
+
+$seen = New-Object System.Collections.Generic.HashSet[string]
+$end = (Get-Date).AddSeconds($DurationSeconds)
+
+Write-Host "Learning normal (filtered) traffic for $DurationSeconds seconds."
+Write-Host "Browse a few normal websites on this computer while this runs."
+
+while ((Get-Date) -lt $end) {
+    Get-NetTCPConnection -State Established -ErrorAction SilentlyContinue |
+        Where-Object { -not (Test-PrivateIP $_.RemoteAddress) } |
+        ForEach-Object { $seen.Add($_.RemoteAddress) | Out-Null }
+    Start-Sleep -Seconds $SampleIntervalSeconds
+}
+
+$allowlist = $seen | Sort-Object
+$allowlist | ConvertTo-Json | Set-Content -Path $OutFile -Encoding UTF8
+
+Write-Host ""
+Write-Host "Done. Recorded $($allowlist.Count) distinct remote IP(s):"
+$allowlist | ForEach-Object { Write-Host "  $_" }
+Write-Host ""
+Write-Host "Saved to: $OutFile"
+Write-Host "Next: copy this IP list into the `$AllowlistIPs array in geder-monitor.ps1"
+Write-Host "before deploying that script to the rest of the fleet."

--- a/geder-filter-monitor/geder-monitor.ps1
+++ b/geder-filter-monitor/geder-monitor.ps1
@@ -1,0 +1,108 @@
+<#
+.SYNOPSIS
+    Detects when a computer has internet traffic going somewhere other
+    than Geder - a sign the filter was removed, disabled, or bypassed
+    (by the user, or by malware/an attacker).
+
+.DESCRIPTION
+    Meant to run on a schedule via NinjaOne (e.g. every 10-15 minutes)
+    across the whole fleet. It lists the computer's currently active
+    outbound connections, ignores private/local addresses, and compares
+    every remaining public IP against a known-good allowlist of Geder's
+    addresses (built once with geder-baseline.ps1).
+
+    If ANY connection is found that isn't in the allowlist:
+      - it's logged to $LogFile with the remote IP/port and the local
+        process that made the connection
+      - it's written to a NinjaOne custom field (if run through the
+        NinjaOne agent) so you can alert on it
+      - the script exits with code 1, which NinjaOne can treat as a
+        failed script result and alert on
+
+    If everything matches the allowlist, it exits 0 and clears the
+    custom field.
+
+.NOTES
+    Before deploying: run geder-baseline.ps1 once on a known-good,
+    properly-filtered PC, then paste the resulting IPs into
+    $AllowlistIPs below. You can also pass -AllowlistIPs as a NinjaOne
+    script parameter (comma-separated) instead of editing the file.
+#>
+
+param(
+    [string[]]$AllowlistIPs = @(
+        # <-- Paste the IPs from geder-baseline.ps1's output here, e.g.:
+        # "203.0.113.10",
+        # "203.0.113.11"
+    ),
+    [string]$AllowlistFile = "$PSScriptRoot\geder-allowlist.json",
+    [string]$LogFile = "$PSScriptRoot\geder-monitor.log",
+    [string]$CustomFieldName = "gederBypassDetected"
+)
+
+function Test-PrivateIP {
+    param([string]$IP)
+    if (-not $IP) { return $true }
+    if ($IP -eq '127.0.0.1' -or $IP -eq '::1' -or $IP -eq '0.0.0.0') { return $true }
+    if ($IP -match '^10\.') { return $true }
+    if ($IP -match '^192\.168\.') { return $true }
+    if ($IP -match '^172\.(1[6-9]|2[0-9]|3[0-1])\.') { return $true }
+    if ($IP -match '^169\.254\.') { return $true }
+    if ($IP -match '^::1$|^fe80:|^fc00:|^fd00:') { return $true }
+    return $false
+}
+
+# Merge the hardcoded list with an optional allowlist file dropped next
+# to the script (handy for testing locally before baking IPs into the
+# script for mass deployment).
+$knownGood = New-Object System.Collections.Generic.HashSet[string]
+foreach ($ip in $AllowlistIPs) { $knownGood.Add($ip) | Out-Null }
+if (Test-Path $AllowlistFile) {
+    (Get-Content $AllowlistFile | ConvertFrom-Json) | ForEach-Object { $knownGood.Add($_) | Out-Null }
+}
+
+if ($knownGood.Count -eq 0) {
+    Write-Error "No allowlist configured. Run geder-baseline.ps1 on a known-good PC first, then populate `$AllowlistIPs or $AllowlistFile."
+    exit 2
+}
+
+$connections = Get-NetTCPConnection -State Established -ErrorAction SilentlyContinue |
+    Where-Object { -not (Test-PrivateIP $_.RemoteAddress) }
+
+$suspicious = @()
+foreach ($conn in $connections) {
+    if (-not $knownGood.Contains($conn.RemoteAddress)) {
+        $proc = Get-Process -Id $conn.OwningProcess -ErrorAction SilentlyContinue
+        $suspicious += [PSCustomObject]@{
+            Time          = (Get-Date).ToString("s")
+            RemoteAddress = $conn.RemoteAddress
+            RemotePort    = $conn.RemotePort
+            Process       = if ($proc) { $proc.ProcessName } else { "Unknown" }
+            Pid           = $conn.OwningProcess
+        }
+    }
+}
+
+if ($suspicious.Count -gt 0) {
+    foreach ($s in $suspicious) {
+        $line = "{0} SUSPICIOUS remote={1}:{2} process={3} pid={4}" -f `
+            $s.Time, $s.RemoteAddress, $s.RemotePort, $s.Process, $s.Pid
+        Add-Content -Path $LogFile -Value $line
+    }
+
+    $summary = "Possible filter bypass: $($suspicious.Count) unknown connection(s) at $(Get-Date -Format s)"
+    Write-Host "ALERT: $summary"
+    $suspicious | Format-Table -AutoSize | Out-String | Write-Host
+
+    if (Get-Command Ninja-Property-Set -ErrorAction SilentlyContinue) {
+        Ninja-Property-Set $CustomFieldName $summary
+    }
+    exit 1
+}
+else {
+    Write-Host "OK: all active connections match the Geder allowlist."
+    if (Get-Command Ninja-Property-Set -ErrorAction SilentlyContinue) {
+        Ninja-Property-Set $CustomFieldName ""
+    }
+    exit 0
+}

--- a/geder-filter-monitor/index.html
+++ b/geder-filter-monitor/index.html
@@ -1,0 +1,184 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Geder Filter Bypass Monitor - Download</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            background: linear-gradient(135deg, #eef4ff 0%, #f7f0ff 100%);
+            min-height: 100vh;
+            display: flex;
+            justify-content: center;
+            padding: 40px 20px;
+            color: #333;
+        }
+
+        .container {
+            background: white;
+            border-radius: 20px;
+            box-shadow: 0 20px 50px rgba(80, 90, 150, 0.15);
+            padding: 50px 45px;
+            max-width: 760px;
+            width: 100%;
+        }
+
+        .icon {
+            text-align: center;
+            font-size: 3em;
+            margin-bottom: 10px;
+        }
+
+        h1 {
+            text-align: center;
+            color: #333;
+            margin-bottom: 12px;
+            font-size: 2em;
+        }
+
+        .subtitle {
+            text-align: center;
+            color: #667;
+            margin-bottom: 35px;
+            font-size: 1.05em;
+            line-height: 1.6;
+            max-width: 560px;
+            margin-left: auto;
+            margin-right: auto;
+        }
+
+        h2 {
+            color: #4d5bce;
+            font-size: 1.15em;
+            margin: 32px 0 14px;
+        }
+
+        .files-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 16px;
+            margin-bottom: 8px;
+        }
+
+        .file-button {
+            background: linear-gradient(135deg, #6d8dff 0%, #8a6ef0 100%);
+            color: white;
+            border: none;
+            padding: 18px 22px;
+            border-radius: 12px;
+            font-size: 0.98em;
+            font-weight: 600;
+            cursor: pointer;
+            transition: all 0.25s ease;
+            text-decoration: none;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            box-shadow: 0 4px 14px rgba(109, 141, 255, 0.35);
+        }
+
+        .file-button:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 8px 20px rgba(109, 141, 255, 0.5);
+        }
+
+        .file-button::before {
+            content: "⬇";
+            margin-right: 8px;
+        }
+
+        .file-caption {
+            text-align: center;
+            color: #888;
+            font-size: 0.85em;
+            margin-top: 12px;
+            margin-bottom: 10px;
+        }
+
+        .steps {
+            background: #f6f8ff;
+            border-radius: 14px;
+            padding: 22px 26px;
+        }
+
+        .steps ol {
+            margin-left: 20px;
+            line-height: 2;
+            font-size: 0.96em;
+        }
+
+        code {
+            background: #e9edff;
+            color: #4d5bce;
+            padding: 3px 8px;
+            border-radius: 5px;
+            font-size: 0.9em;
+            font-family: 'Consolas', 'Courier New', monospace;
+        }
+
+        .tip {
+            background: #eefaf1;
+            border-radius: 12px;
+            padding: 16px 20px;
+            color: #2e7d4f;
+            font-size: 0.9em;
+            margin-top: 25px;
+            line-height: 1.6;
+        }
+
+        .tip strong {
+            display: block;
+            margin-bottom: 4px;
+        }
+
+        .footer-note {
+            text-align: center;
+            color: #999;
+            font-size: 0.85em;
+            margin-top: 30px;
+            padding-top: 20px;
+            border-top: 1px solid #eee;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="icon">🛡️</div>
+        <h1>Geder Filter Bypass Monitor</h1>
+        <p class="subtitle">Two PowerShell scripts for IT admins deploying through NinjaOne. They watch each managed computer and let you know the moment its traffic stops going through Geder - a sign the filter may have been removed, disabled, or bypassed.</p>
+
+        <div class="files-grid">
+            <a href="geder-baseline.ps1" class="file-button" download>Baseline Script</a>
+            <a href="geder-monitor.ps1" class="file-button" download>Monitor Script</a>
+            <a href="README.md" class="file-button" download>Setup Guide</a>
+        </div>
+        <p class="file-caption">Full step-by-step NinjaOne setup is in the Setup Guide.</p>
+
+        <h2>The short version</h2>
+        <div class="steps">
+            <ol>
+                <li>Run <code>geder-baseline.ps1</code> once on a computer you know is properly filtered - it records what "normal, filtered" traffic looks like.</li>
+                <li>Paste the results into <code>geder-monitor.ps1</code>.</li>
+                <li>Upload <code>geder-monitor.ps1</code> to NinjaOne and schedule it to run on your fleet every 10-15 minutes.</li>
+                <li>Set up a NinjaOne alert condition on the script result - now you'll be notified automatically if any computer's traffic goes somewhere Geder wouldn't allow.</li>
+            </ol>
+        </div>
+
+        <div class="tip">
+            <strong>💡 Good to know</strong>
+            This checks which addresses a computer is talking to, not full packet capture - so it's safe and lightweight to run across every managed endpoint, with nothing extra to install.
+        </div>
+
+        <div class="footer-note">
+            <p>For IT administrators monitoring devices they manage. Read the Setup Guide before deploying fleet-wide.</p>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds `geder-filter-monitor/geder-baseline.ps1` — a one-time script run manually on a known-good, properly filtered PC. It samples active outbound connections for a few minutes and saves every distinct public remote IP as a JSON allowlist ("what normal, filtered traffic looks like").
- Adds `geder-filter-monitor/geder-monitor.ps1` — the script to deploy fleet-wide through NinjaOne on a schedule (e.g. every 10-15 min). It lists each computer's current connections, ignores private/local IPs, and compares the rest against the allowlist. Any connection outside the allowlist is logged, written to a NinjaOne custom field (`gederBypassDetected`) via `Ninja-Property-Set`, and causes the script to exit 1 so a NinjaOne alert condition can fire.
- Uses only built-in Windows connection listing (`Get-NetTCPConnection`) — no Wireshark/Npcap install needed on every endpoint, which matters when pushing to a large fleet.
- Adds `geder-filter-monitor/README.md` with full NinjaOne deployment steps (custom field, script upload, scheduling, alert condition) and `geder-filter-monitor/index.html`, a download page matching the site's existing style.

This is purely additive — no existing files were touched.

## Test plan
- [x] Reviewed both PowerShell scripts by hand for syntax (no `pwsh` available in this sandbox to execute-check)
- [ ] Run `geder-baseline.ps1` on a real, properly-filtered Windows PC to confirm it captures Geder's IPs
- [ ] Run `geder-monitor.ps1` on a test PC and confirm it flags a connection when Geder is disabled/bypassed
- [ ] Confirm `Ninja-Property-Set` custom field updates and the NinjaOne alert condition fires end-to-end


---
_Generated by [Claude Code](https://claude.ai/code/session_0148LbaojJ7L8vbJnD4W8CW3)_