### PR TITLE
Restyle password generator to match files.linearit.co

### DIFF
--- a/password/index.html
+++ b/password/index.html
@@ -1,211 +1,232 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Password Generator - Linear Tech</title>
-  <meta name="description" content="Generate strong, random passwords of any length right in your browser." />
-  <link rel="stylesheet" href="../style.css" />
-  <style>
-    .pwgen-wrap { max-width: 640px; margin: 40px auto; padding: 0 16px; }
-    .pwgen-card {
-      background: rgba(0, 34, 68, 0.55);
-      border: 1px solid rgba(255, 255, 255, 0.15);
-      border-radius: 10px;
-      padding: 28px;
-    }
-    .pwgen-card h1 { margin-top: 0; }
-    .pwgen-output {
-      display: flex;
-      gap: 8px;
-      margin: 20px 0;
-    }
-    #pwOutput {
-      flex: 1;
-      font-family: "Courier New", monospace;
-      font-size: 18px;
-      padding: 12px;
-      border-radius: 6px;
-      border: 1px solid rgba(255, 255, 255, 0.25);
-      background: rgba(255, 255, 255, 0.08);
-      color: #fff;
-    }
-    .pwgen-output button {
-      padding: 10px 18px;
-      border: none;
-      border-radius: 6px;
-      background: #ff6600;
-      color: #fff;
-      font-weight: bold;
-      cursor: pointer;
-      white-space: nowrap;
-    }
-    .pwgen-output button:hover { background: #cc5200; }
-    .pwgen-row {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      margin-bottom: 14px;
-    }
-    .pwgen-row label { font-weight: bold; }
-    .pwgen-options label {
-      display: flex;
-      align-items: center;
-      gap: 8px;
-      margin-bottom: 10px;
-      font-weight: normal;
-      cursor: pointer;
-    }
-    #pwLength { width: 70px; text-align: center; }
-    #pwLengthRange { flex: 1; margin: 0 14px; }
-    #pwCopiedMsg {
-      font-size: 13px;
-      color: #9be89b;
-      height: 18px;
-      margin-top: -10px;
-    }
-    #generateBtn {
-      width: 100%;
-      padding: 12px;
-      border: none;
-      border-radius: 6px;
-      background: #ff6600;
-      color: #fff;
-      font-weight: bold;
-      font-size: 16px;
-      cursor: pointer;
-      margin-top: 6px;
-    }
-    #generateBtn:hover { background: #cc5200; }
-  </style>
+<meta charset="UTF-8"/>
+<meta name="viewport" content="width=device-width,initial-scale=1"/>
+<title>Password Generator - Linear Tech</title>
+<meta name="description" content="Generate strong, random passwords of any length right in your browser."/>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+<style>
+*{box-sizing:border-box;margin:0;padding:0}
+
+/* ── Dark theme (default) ── */
+:root,[data-theme="dark"]{
+  --bg:#0f1117;--bg2:#1a1d27;--bg3:#222536;
+  --text:#eef0f6;--muted:#7c85a2;--muted2:#4e5571;
+  --accent:#4f7ef8;--accent-h:#3b6cf5;--accent-bg:rgba(79,126,248,.12);
+  --border:#2a2f45;--border2:#353b56;
+  --card:#181c2a;--card2:#1e2235;
+  --success:#4ade80;--success-bg:rgba(74,222,128,.12);
+  --shadow:0 2px 16px rgba(0,0,0,.4);
+  --input-bg:#0f1117;
+}
+
+/* ── Light theme ── */
+[data-theme="light"]{
+  --bg:#f4f6fb;--bg2:#ffffff;--bg3:#eef0f8;
+  --text:#1a1d2e;--muted:#5a6080;--muted2:#9aa0bc;
+  --accent:#3b6cf5;--accent-h:#2955d8;--accent-bg:rgba(59,108,245,.08);
+  --border:#dde1ee;--border2:#c8cee0;
+  --card:#ffffff;--card2:#f8f9fd;
+  --success:#16a34a;--success-bg:rgba(22,163,74,.08);
+  --shadow:0 2px 16px rgba(0,0,0,.08);
+  --input-bg:#f4f6fb;
+}
+
+body{font-family:'Plus Jakarta Sans',system-ui,sans-serif;background:var(--bg);color:var(--text);min-height:100vh;line-height:1.5;transition:background .2s,color .2s}
+
+/* ── Header ── */
+header{background:var(--bg2);border-bottom:1px solid var(--border);padding:0 28px;height:64px;display:flex;align-items:center;justify-content:space-between;position:sticky;top:0;z-index:10;box-shadow:var(--shadow)}
+.logo{display:flex;align-items:center;gap:10px}
+.logo-icon{width:32px;height:32px;background:var(--accent);border-radius:8px;display:flex;align-items:center;justify-content:center}
+.logo-icon svg{width:18px;height:18px;stroke:#fff;fill:none;stroke-width:2}
+.logo-text{font-size:1.05rem;font-weight:700;color:var(--text);letter-spacing:-.02em}
+.logo-text span{color:var(--accent)}
+#theme-toggle{background:var(--bg3);border:1px solid var(--border);color:var(--muted);width:36px;height:36px;border-radius:50%;cursor:pointer;display:flex;align-items:center;justify-content:center;transition:all .2s;flex-shrink:0}
+#theme-toggle:hover{border-color:var(--accent);color:var(--accent)}
+
+/* ── Layout ── */
+main{max-width:640px;margin:0 auto;padding:44px 20px}
+
+/* ── Card ── */
+.card{background:var(--card);border:1px solid var(--border);border-radius:16px;padding:32px;box-shadow:var(--shadow);transition:background .2s,border-color .2s}
+.card-title{font-size:1.4rem;font-weight:700;margin-bottom:8px;color:var(--text)}
+.card-desc{font-size:.88rem;color:var(--muted);margin-bottom:26px;line-height:1.6}
+
+/* ── Output row ── */
+.output-row{display:flex;gap:10px;margin-bottom:26px}
+#pwOutput{
+  flex:1;background:var(--input-bg);border:1px solid var(--border2);color:var(--text);
+  padding:12px 15px;border-radius:10px;font-size:.95rem;outline:none;font-family:monospace;
+  transition:border-color .15s,box-shadow .15s
+}
+#pwOutput:focus{border-color:var(--accent);box-shadow:0 0 0 3px var(--accent-bg)}
+
+.btn{display:inline-flex;align-items:center;justify-content:center;gap:7px;background:var(--accent);color:#fff;border:none;padding:11px 22px;
+  border-radius:10px;cursor:pointer;font-size:.92rem;font-weight:600;font-family:inherit;transition:all .15s;letter-spacing:-.01em;white-space:nowrap}
+.btn:hover{background:var(--accent-h);transform:translateY(-1px);box-shadow:0 4px 12px rgba(79,126,248,.3)}
+.btn:active{transform:none}
+.btn-full{width:100%;margin-top:6px}
+
+#copy-msg{font-size:.8rem;color:var(--success);height:16px;margin:-18px 0 18px;font-weight:500}
+
+/* ── Length row ── */
+.field{margin-bottom:18px}
+label{display:block;font-size:.82rem;color:var(--muted);margin-bottom:7px;font-weight:600;letter-spacing:.01em}
+.length-row{display:flex;align-items:center;gap:14px;margin-bottom:22px}
+.length-row label{margin-bottom:0;flex-shrink:0}
+input[type=range]{flex:1;accent-color:var(--accent);cursor:pointer}
+input[type=number]{
+  width:64px;background:var(--input-bg);border:1px solid var(--border2);color:var(--text);
+  padding:8px 10px;border-radius:8px;font-size:.9rem;text-align:center;outline:none;font-family:inherit
+}
+input[type=number]:focus{border-color:var(--accent);box-shadow:0 0 0 3px var(--accent-bg)}
+
+/* ── Options ── */
+.options{margin-bottom:24px}
+.opt{display:flex;align-items:center;gap:10px;margin-bottom:12px;cursor:pointer;font-size:.9rem;color:var(--text);user-select:none}
+.opt input[type=checkbox]{width:17px;height:17px;accent-color:var(--accent);cursor:pointer;flex-shrink:0}
+</style>
 </head>
-<body class="background">
-  <header>
-    <img src="../assets/logo.png" alt="Linear Tech Logo" class="logo" />
-    <nav>
-      <a href="../index.html">Home</a>
-      <a href="../about.html">About</a>
-      <a href="../services.html">Services</a>
-      <a href="../contact.html">Contact</a>
-      <a href="../password/" class="active">Password Generator</a>
-    </nav>
-    <a href="https://linearit.screenconnect.com/Bin/ScreenConnect.ClientSetup.exe?e=Access&y=Guest" class="button remote-header">Get Remote Support Now!</a>
-  </header>
-
-  <main>
-    <div class="pwgen-wrap">
-      <div class="pwgen-card">
-        <h1>Password Generator</h1>
-        <p>Pick a length and character types, then generate a strong password. Everything happens in your browser — nothing is sent anywhere.</p>
-
-        <div class="pwgen-output">
-          <input type="text" id="pwOutput" readonly aria-label="Generated password" />
-          <button id="copyBtn" type="button">Copy</button>
-        </div>
-        <div id="pwCopiedMsg"></div>
-
-        <div class="pwgen-row">
-          <label for="pwLengthRange">Length</label>
-          <input type="range" id="pwLengthRange" min="4" max="64" value="16" />
-          <input type="number" id="pwLength" min="4" max="64" value="16" />
-        </div>
-
-        <div class="pwgen-options">
-          <label><input type="checkbox" id="optUpper" checked /> Uppercase letters (A-Z)</label>
-          <label><input type="checkbox" id="optLower" checked /> Lowercase letters (a-z)</label>
-          <label><input type="checkbox" id="optNumbers" checked /> Numbers (0-9)</label>
-          <label><input type="checkbox" id="optSymbols" /> Symbols (!@#$%^&*)</label>
-        </div>
-
-        <button id="generateBtn" type="button">Generate Password</button>
-      </div>
+<body>
+<header>
+  <div class="logo">
+    <div class="logo-icon">
+      <svg viewBox="0 0 24 24"><rect x="5" y="11" width="14" height="10" rx="2"/><path d="M8 11V7a4 4 0 018 0v4" stroke-linecap="round"/></svg>
     </div>
-  </main>
+    <span class="logo-text">Linear<span>Tech</span></span>
+  </div>
+  <button id="theme-toggle" title="Toggle light/dark mode" onclick="toggleTheme()">
+    <svg id="icon-moon" width="17" height="17" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z" stroke-linecap="round" stroke-linejoin="round"/></svg>
+    <svg id="icon-sun" width="17" height="17" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" style="display:none"><circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42" stroke-linecap="round"/></svg>
+  </button>
+</header>
 
-  <footer>
-    <p>Contact us: 845-604-1462 | <a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="4f3c3a3f3f203d3b0f2326212a2e3d263b612c20">[email&#160;protected]</a></p>
-    <p>&copy; 2025 Linear Tech. All rights reserved.</p>
-  </footer>
-  <script data-cfasync="false" src="/cdn-cgi/scripts/5c5dd728/cloudflare-static/email-decode.min.js"></script>
+<main>
+  <div class="card">
+    <div class="card-title">Password Generator</div>
+    <div class="card-desc">Pick a length and character types, then generate a strong password. Everything happens in your browser — nothing is sent anywhere.</div>
 
-  <script>
-    (function () {
-      const lengthRange = document.getElementById('pwLengthRange');
-      const lengthInput = document.getElementById('pwLength');
-      const optUpper = document.getElementById('optUpper');
-      const optLower = document.getElementById('optLower');
-      const optNumbers = document.getElementById('optNumbers');
-      const optSymbols = document.getElementById('optSymbols');
-      const output = document.getElementById('pwOutput');
-      const generateBtn = document.getElementById('generateBtn');
-      const copyBtn = document.getElementById('copyBtn');
-      const copiedMsg = document.getElementById('pwCopiedMsg');
+    <div class="output-row">
+      <input type="text" id="pwOutput" readonly aria-label="Generated password"/>
+      <button class="btn" id="copyBtn" type="button">Copy</button>
+    </div>
+    <div id="copy-msg"></div>
 
-      const CHARSETS = {
-        upper: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
-        lower: 'abcdefghijklmnopqrstuvwxyz',
-        numbers: '0123456789',
-        symbols: '!@#$%^&*()_+-=[]{}|;:,.<>?'
-      };
+    <div class="length-row">
+      <label for="pwLengthRange">Length</label>
+      <input type="range" id="pwLengthRange" min="4" max="64" value="16"/>
+      <input type="number" id="pwLength" min="4" max="64" value="16"/>
+    </div>
 
-      function syncLength(value) {
-        const clamped = Math.min(64, Math.max(4, parseInt(value, 10) || 16));
-        lengthRange.value = clamped;
-        lengthInput.value = clamped;
-      }
+    <div class="options">
+      <label class="opt"><input type="checkbox" id="optUpper" checked/> Uppercase letters (A-Z)</label>
+      <label class="opt"><input type="checkbox" id="optLower" checked/> Lowercase letters (a-z)</label>
+      <label class="opt"><input type="checkbox" id="optNumbers" checked/> Numbers (0-9)</label>
+      <label class="opt"><input type="checkbox" id="optSymbols"/> Symbols (!@#$%^&*)</label>
+    </div>
 
-      function randomInt(max) {
-        const array = new Uint32Array(1);
-        crypto.getRandomValues(array);
-        return array[0] % max;
-      }
+    <button class="btn btn-full" id="generateBtn" type="button">Generate Password</button>
+  </div>
+</main>
 
-      function generatePassword() {
-        const pools = [];
-        if (optUpper.checked) pools.push(CHARSETS.upper);
-        if (optLower.checked) pools.push(CHARSETS.lower);
-        if (optNumbers.checked) pools.push(CHARSETS.numbers);
-        if (optSymbols.checked) pools.push(CHARSETS.symbols);
+<script>
+function toggleTheme() {
+  var t = document.documentElement.getAttribute("data-theme") === "light" ? "dark" : "light";
+  document.documentElement.setAttribute("data-theme", t);
+  document.getElementById("icon-moon").style.display = t === "dark" ? "block" : "none";
+  document.getElementById("icon-sun").style.display = t === "light" ? "block" : "none";
+  try { localStorage.setItem("theme", t); } catch(e) {}
+}
+(function () {
+  var t;
+  try { t = localStorage.getItem("theme"); } catch(e) { t = null; }
+  t = t || "dark";
+  document.documentElement.setAttribute("data-theme", t);
+  if (t === "light") {
+    document.getElementById("icon-moon").style.display = "none";
+    document.getElementById("icon-sun").style.display = "block";
+  }
+})();
 
-        if (pools.length === 0) {
-          optLower.checked = true;
-          pools.push(CHARSETS.lower);
-        }
+(function () {
+  const lengthRange = document.getElementById('pwLengthRange');
+  const lengthInput = document.getElementById('pwLength');
+  const optUpper = document.getElementById('optUpper');
+  const optLower = document.getElementById('optLower');
+  const optNumbers = document.getElementById('optNumbers');
+  const optSymbols = document.getElementById('optSymbols');
+  const output = document.getElementById('pwOutput');
+  const generateBtn = document.getElementById('generateBtn');
+  const copyBtn = document.getElementById('copyBtn');
+  const copiedMsg = document.getElementById('copy-msg');
 
-        const length = parseInt(lengthInput.value, 10) || 16;
-        const allChars = pools.join('');
-        const passwordChars = [];
+  const CHARSETS = {
+    upper: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+    lower: 'abcdefghijklmnopqrstuvwxyz',
+    numbers: '0123456789',
+    symbols: '!@#$%^&*()_+-=[]{}|;:,.<>?'
+  };
 
-        pools.forEach(pool => {
-          passwordChars.push(pool[randomInt(pool.length)]);
-        });
-        while (passwordChars.length < length) {
-          passwordChars.push(allChars[randomInt(allChars.length)]);
-        }
+  function syncLength(value) {
+    const clamped = Math.min(64, Math.max(4, parseInt(value, 10) || 16));
+    lengthRange.value = clamped;
+    lengthInput.value = clamped;
+  }
 
-        for (let i = passwordChars.length - 1; i > 0; i--) {
-          const j = randomInt(i + 1);
-          [passwordChars[i], passwordChars[j]] = [passwordChars[j], passwordChars[i]];
-        }
+  function randomInt(max) {
+    const array = new Uint32Array(1);
+    crypto.getRandomValues(array);
+    return array[0] % max;
+  }
 
-        output.value = passwordChars.slice(0, length).join('');
-        copiedMsg.textContent = '';
-      }
+  function generatePassword() {
+    const pools = [];
+    if (optUpper.checked) pools.push(CHARSETS.upper);
+    if (optLower.checked) pools.push(CHARSETS.lower);
+    if (optNumbers.checked) pools.push(CHARSETS.numbers);
+    if (optSymbols.checked) pools.push(CHARSETS.symbols);
 
-      lengthRange.addEventListener('input', () => syncLength(lengthRange.value));
-      lengthInput.addEventListener('input', () => syncLength(lengthInput.value));
-      generateBtn.addEventListener('click', generatePassword);
+    if (pools.length === 0) {
+      optLower.checked = true;
+      pools.push(CHARSETS.lower);
+    }
 
-      copyBtn.addEventListener('click', () => {
-        if (!output.value) return;
-        navigator.clipboard.writeText(output.value).then(() => {
-          copiedMsg.textContent = 'Copied to clipboard!';
-          setTimeout(() => { copiedMsg.textContent = ''; }, 2000);
-        });
-      });
+    const length = parseInt(lengthInput.value, 10) || 16;
+    const allChars = pools.join('');
+    const passwordChars = [];
 
-      generatePassword();
-    })();
-  </script>
+    pools.forEach(pool => {
+      passwordChars.push(pool[randomInt(pool.length)]);
+    });
+    while (passwordChars.length < length) {
+      passwordChars.push(allChars[randomInt(allChars.length)]);
+    }
+
+    for (let i = passwordChars.length - 1; i > 0; i--) {
+      const j = randomInt(i + 1);
+      [passwordChars[i], passwordChars[j]] = [passwordChars[j], passwordChars[i]];
+    }
+
+    output.value = passwordChars.slice(0, length).join('');
+    copiedMsg.textContent = '';
+  }
+
+  lengthRange.addEventListener('input', () => syncLength(lengthRange.value));
+  lengthInput.addEventListener('input', () => syncLength(lengthInput.value));
+  generateBtn.addEventListener('click', generatePassword);
+
+  copyBtn.addEventListener('click', () => {
+    if (!output.value) return;
+    navigator.clipboard.writeText(output.value).then(() => {
+      copiedMsg.textContent = 'Copied to clipboard!';
+      setTimeout(() => { copiedMsg.textContent = ''; }, 2000);
+    });
+  });
+
+  generatePassword();
+})();
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Removes the marketing header/nav and footer from `/password`
- Restyles the page to match the `files.linearit.co` design system (Plus Jakarta Sans, same dark/light CSS variables, card/button styles)
- Adds the moon/sun theme toggle button, with the choice persisted via `localStorage`

## Test plan
- [x] Verified in a headless browser: no marketing nav/footer present, dark theme by default, toggle flips to light theme and colors update correctly, theme choice persists across reload
- [x] Confirmed password generation, length control, and copy-to-clipboard still work
- [x] No JS console errors


---
_Generated by [Claude Code](https://claude.ai/code/session_017uTWD7K4RWWs1z8yvVCSBQ)_