### PR TITLE
Device report: optional PowerShell deep scan for unmanaged PCs

### DIFF
--- a/device/index.html
+++ b/device/index.html
@@ -195,6 +195,18 @@ select:focus{outline:none;border-color:var(--aqua)}
 .ftest iframe{width:100%;height:210px;border:0;display:block;background:#fff}
 .ftest-link a{flex:1;display:grid;place-items:center;text-align:center;color:var(--aqua);font-weight:600;font-size:.85rem;padding:24px 10px;background:var(--panel);text-decoration:none;line-height:1.4}
 .ftest-link small{color:var(--dim);font-weight:400}
+.scan-cmd{display:flex;gap:8px;align-items:stretch;margin-top:12px;flex-wrap:wrap}
+.scan-cmd code{flex:1;min-width:220px;font-family:ui-monospace,Menlo,Consolas,monospace;font-size:.82rem;background:#05060a;border:1px solid var(--line);border-radius:8px;padding:10px 12px;color:var(--aqua);overflow-x:auto;white-space:nowrap;display:flex;align-items:center}
+.scan-help{font-size:.78rem;color:var(--dim);margin-top:9px}
+.scan-actions{display:flex;gap:8px;flex-wrap:wrap;margin-top:12px}
+.scan-actions .btn{text-decoration:none}
+#scan-paste-wrap{margin-top:12px}
+#scan-paste{width:100%;height:88px;font-family:ui-monospace,Menlo,Consolas,monospace;font-size:.76rem;background:var(--panel);border:1px solid var(--line);border-radius:8px;color:var(--txt);padding:10px;resize:vertical;margin-bottom:8px}
+#scan-paste:focus{outline:none;border-color:var(--aqua)}
+.scan-status{margin-top:10px;font-size:.82rem;font-weight:500;min-height:1.1em}
+.scan-status.ok{color:var(--ok)}
+.scan-status.err{color:var(--warn)}
+.scan-status.busy{color:var(--dim)}
 
 .spark{display:flex;gap:2px;align-items:flex-end;height:30px;margin-top:8px}
 .spark i{flex:1;background:linear-gradient(180deg,var(--aqua),var(--peri));border-radius:2px;min-height:2px;opacity:.85}
@@ -365,6 +377,28 @@ footer .contact{display:flex;gap:8px 20px;justify-content:center;flex-wrap:wrap;
     <div class="sub" data-sub></div>
     <dl class="rows" data-rows></dl>
     <div class="note">Device power-on uptime isn't available to browsers. This shows how long this page/session has been open. True uptime requires the agent.</div>
+  </article>
+
+  <!-- FULL SYSTEM SCAN (Windows) -->
+  <article class="card span-2" id="c-scan">
+    <div class="card-head"><span class="ico">🪟</span><h3>Full System Scan (Windows)</h3><span class="chip agent" data-chip>Optional</span></div>
+    <div class="sub" data-sub>No install. Fills the agent-only fields — installed apps, admin/standard users, real disk size, uptime, CPU speed, installed filter.</div>
+    <div class="scan-cmd">
+      <code id="scan-oneliner">irm https://www.linearit.co/device/scan.ps1 | iex</code>
+      <button class="btn" id="btn-scan-copy" type="button">Copy</button>
+    </div>
+    <div class="scan-help">Run in <b>PowerShell</b> (Admin recommended). It copies a report to your clipboard and opens a local bridge for ~5&nbsp;min.</div>
+    <div class="scan-actions">
+      <button class="btn primary" id="btn-scan-pull" type="button">📥 Pull from this PC</button>
+      <button class="btn" id="btn-scan-paste-toggle" type="button">📋 Paste report</button>
+      <a class="btn" href="/device/scan.ps1" download>⬇ Download .ps1</a>
+    </div>
+    <div id="scan-paste-wrap" hidden>
+      <textarea id="scan-paste" placeholder="Paste the report code the script copied to your clipboard, then click Load…"></textarea>
+      <button class="btn primary" id="btn-scan-load" type="button">Load report</button>
+    </div>
+    <div class="scan-status" id="scan-status"></div>
+    <div class="note">The script reads only this PC's own inventory, installs nothing, and listens only on localhost. <b>Pull from this PC</b> works when the script and this page run on the <b>same</b> computer; otherwise use <b>Paste report</b> (works from any device — run on the client's PC, paste on your phone).</div>
   </article>
 
   <!-- USERS -->
@@ -1240,6 +1274,139 @@ footer .contact{display:flex;gap:8px 20px;justify-content:center;flex-wrap:wrap;
   $('#btn-send2').addEventListener('click', doSend);
   $('#btn-retest').addEventListener('click', function(){ if(!speedRunning){ speedTest(); } });
   $('#btn-refresh').addEventListener('click', function(){ location.reload(); });
+
+  /* =====================================================================
+     FULL SYSTEM SCAN (Windows) — fills the agent-only cards from scan.ps1
+     Data arrives via the local bridge (fetch) or by pasting the report.
+     ===================================================================== */
+  function scanStatus(msg, cls){ var s=$('#scan-status'); if(!s) return; s.className='scan-status '+(cls||''); s.textContent=msg; }
+  var SCAN_CMD = 'irm https://www.linearit.co/device/scan.ps1 | iex';
+
+  function applyScan(d){
+    if(!d || typeof d!=='object' || String(d.schema||'').indexOf('linear-device')!==0){
+      scanStatus('That doesn’t look like a Linear scan report — copy it again from the script.', 'err'); return false;
+    }
+    // Windows PowerShell 5.1 serializes single-element arrays as a lone object —
+    // coerce the fields we treat as lists back into arrays.
+    function arr(x){ return Array.isArray(x) ? x : (x==null ? [] : [x]); }
+    d.disks = arr(d.disks);
+    d.filters = arr(d.filters);
+    if(d.apps) d.apps.list = arr(d.apps.list);
+    if(d.ram) d.ram.modules = arr(d.ram.modules);
+    if(d.users){ d.users.admins = arr(d.users.admins); d.users.standard = arr(d.users.standard); }
+    if(d.security) d.security.antivirus = arr(d.security.antivirus);
+    try {
+      if(d.users){
+        var u=d.users;
+        setChip('c-users','live','Scan');
+        setBig('c-users', (u.adminCount||0)+' <span class="unit">admin</span> · '+(u.standardCount||0)+' <span class="unit">standard</span>');
+        setSub('c-users','Local accounts on this PC');
+        setRows('c-users',[
+          ['Administrators', (u.admins&&u.admins.length)? u.admins.join(', ') : String(u.adminCount||0)],
+          ['Standard users', (u.standard&&u.standard.length)? u.standard.join(', ') : String(u.standardCount||0)],
+          ['Signed in now', u.current]
+        ]);
+        rec('User accounts', (u.adminCount||0)+' admin / '+(u.standardCount||0)+' standard'+((u.admins&&u.admins.length)?(' — admins: '+u.admins.join(', ')):''));
+      }
+      if(d.apps){
+        var a=d.apps, list=a.list||[];
+        setChip('c-apps','live','Scan');
+        setBig('c-apps', (a.count!=null?a.count:list.length)+' <span class="unit">installed</span>');
+        setSub('c-apps','Software inventory');
+        var top=list.slice(0,14).map(function(x){ return [x.name, x.version||'—', true]; });
+        if(list.length>14) top.push(['…','+'+(list.length-14)+' more']);
+        setRows('c-apps', top);
+        rec('Installed apps', (a.count!=null?a.count:list.length)+' apps'+(list.length?(' incl. '+list.slice(0,8).map(function(x){return x.name;}).join(', ')):''));
+      }
+      if(d.disks && d.disks.length){
+        var m=d.disks[0];
+        setChip('c-disk','live','Scan');
+        setBig('c-disk', (m.freeGB!=null?m.freeGB:'?')+' <span class="unit">GB free of '+(m.sizeGB!=null?m.sizeGB+' GB':'?')+'</span>');
+        setSub('c-disk','Actual drive'+(d.disks.length>1?'s':''));
+        setMeter('c-disk', m.usedPct!=null?m.usedPct:0, (m.usedPct||0)>=85);
+        setRows('c-disk', d.disks.map(function(dk){ return [dk.drive+(dk.label?(' '+dk.label):''), (dk.freeGB!=null?dk.freeGB:'?')+' free / '+(dk.sizeGB!=null?dk.sizeGB:'?')+' GB', true]; }));
+        rec('Storage', d.disks.map(function(dk){ return dk.drive+' '+dk.freeGB+'/'+dk.sizeGB+' GB free'; }).join('; '));
+      }
+      if(d.os && d.os.uptimeSec!=null){
+        setChip('c-uptime','live','Scan');
+        setBig('c-uptime', fmtDur(d.os.uptimeSec*1000));
+        setSub('c-uptime','Since last boot (actual)');
+        setRows('c-uptime',[
+          ['Last boot', d.os.lastBoot? new Date(d.os.lastBoot).toLocaleString() : '—'],
+          ['OS installed', d.os.installed||'—']
+        ]);
+        rec('Device uptime', fmtDur(d.os.uptimeSec*1000)+(d.os.lastBoot?(' (since '+new Date(d.os.lastBoot).toLocaleString()+')'):''));
+      }
+      if(d.cpu){
+        var crows=[['Processor', d.cpu.name],['Cores', d.cpu.cores+' cores / '+d.cpu.logical+' threads', true]];
+        if(d.cpu.maxClockMhz) crows.push(['Clock speed', (d.cpu.maxClockMhz/1000).toFixed(2)+' GHz', true]);
+        setSub('c-cpu', d.cpu.name);
+        setRows('c-cpu', crows);
+        rec('CPU', d.cpu.name+(d.cpu.maxClockMhz?(' @ '+(d.cpu.maxClockMhz/1000).toFixed(2)+' GHz'):''));
+      }
+      if(d.ram && d.ram.totalGB!=null){
+        setChip('c-ram','live','Scan');
+        setBig('c-ram', d.ram.totalGB+' <span class="unit">GB</span>');
+        setSub('c-ram','Installed (actual)');
+        var rr=[['Total', d.ram.totalGB+' GB', true], ['Slots used', (d.ram.slotsUsed||'?')+(d.ram.slotsTotal?(' of '+d.ram.slotsTotal):''), true]];
+        (d.ram.modules||[]).forEach(function(mm,i){ rr.push(['Module '+(i+1), mm.sizeGB+' GB'+(mm.speedMhz?(' @ '+mm.speedMhz+' MHz'):''), true]); });
+        setRows('c-ram', rr);
+        rec('RAM', d.ram.totalGB+' GB'+(d.ram.slotsUsed?(' ('+d.ram.slotsUsed+(d.ram.slotsTotal?('/'+d.ram.slotsTotal):'')+' slots)'):''));
+      }
+      if(d.computer){
+        var c=d.computer, el=$('[data-rows]',card('c-os'));
+        if(el){
+          [['Make / model',[c.manufacturer,c.model].filter(Boolean).join(' ')],['Serial',c.serial],['Domain / workgroup',c.domain]].forEach(function(p){
+            if(!p[1]) return; var dt=document.createElement('dt'); dt.textContent=p[0]; var dd=document.createElement('dd'); dd.textContent=p[1]; el.appendChild(dt); el.appendChild(dd);
+          });
+        }
+        rec('Computer', c.name+(c.model?(' ('+[c.manufacturer,c.model].filter(Boolean).join(' ')+')'):''));
+      }
+      if(d.filters && d.filters.length){
+        FILTER.confirmed = true;
+        setChip('c-filter','live','Installed');
+        setBig('c-filter', esc(d.filters.join(', ')));
+        setSub('c-filter','Installed on this PC (from system scan)');
+        setRows('c-filter',[['Installed filter', d.filters.join(', ')],['Source','Windows software / service scan']]);
+        rec('Content filter', d.filters.join(', ')+' (installed — from scan)');
+      }
+      if(d.security && (d.security.antivirus||d.security.firewall||d.security.bitlocker)){
+        var be=$('[data-rows]',card('c-browser'));
+        if(be){
+          [['Antivirus',(d.security.antivirus||[]).join(', ')],['Firewall',d.security.firewall],['BitLocker (C:)',d.security.bitlocker]].forEach(function(p){
+            if(!p[1]) return; var dt=document.createElement('dt'); dt.textContent=p[0]; var dd=document.createElement('dd'); dd.textContent=p[1]; be.appendChild(dt); be.appendChild(dd);
+          });
+        }
+      }
+      $('#c-scan').querySelector('[data-chip]').className='chip live'; $('#c-scan').querySelector('[data-chip]').textContent='Loaded';
+      scanStatus('✅ Full scan loaded'+((d.computer&&d.computer.name)?(' for '+d.computer.name):'')+(d.admin?'':' — run as Administrator for a couple more fields')+'.', 'ok');
+      buildSummary(); toast('🪟 Full system scan loaded');
+      return true;
+    } catch(e){ scanStatus('Loaded, but a field failed: '+e.message, 'err'); return false; }
+  }
+
+  function pullFromPC(){
+    scanStatus('Looking for the scan on this PC…', 'busy');
+    var ctrl = ('AbortController' in window)? new AbortController() : null;
+    var to = setTimeout(function(){ if(ctrl) ctrl.abort(); }, 4500);
+    fetch('http://127.0.0.1:8765/report.json?_='+Date.now(), {cache:'no-store', signal: ctrl?ctrl.signal:undefined})
+      .then(function(r){ return r.json(); })
+      .then(function(d){ clearTimeout(to); applyScan(d); })
+      .catch(function(){ clearTimeout(to); scanStatus('Couldn’t reach a local scan. Run the command above on THIS PC (keep its window open), then click again — or use “Paste report”.', 'err'); });
+  }
+
+  $('#btn-scan-copy').addEventListener('click', function(){
+    if(navigator.clipboard && navigator.clipboard.writeText){ navigator.clipboard.writeText(SCAN_CMD).then(function(){ toast('📋 Command copied'); }).catch(function(){ legacyCopy(SCAN_CMD); }); }
+    else legacyCopy(SCAN_CMD);
+  });
+  $('#btn-scan-pull').addEventListener('click', pullFromPC);
+  $('#btn-scan-paste-toggle').addEventListener('click', function(){ var w=$('#scan-paste-wrap'); w.hidden=!w.hidden; if(!w.hidden) $('#scan-paste').focus(); });
+  $('#btn-scan-load').addEventListener('click', function(){
+    var v=($('#scan-paste').value||'').trim();
+    if(!v){ scanStatus('Paste the report text first.', 'err'); return; }
+    var d; try{ d=JSON.parse(v); }catch(e){ scanStatus('That isn’t valid report text — re-copy it from the script.', 'err'); return; }
+    applyScan(d);
+  });
 
   /* =====================================================================
      BOOT

--- a/device/scan.ps1
+++ b/device/scan.ps1
@@ -1,0 +1,253 @@
+<#
+  Linear IT — Device Deep Scan
+  ==========================================================================
+  Collects the details a web browser is NOT allowed to see (installed apps,
+  admin vs. standard users, real disk size, OS uptime, CPU clock speed, RAM
+  modules, installed content filter, etc.) and hands them to the dashboard at
+  device.linearit.co in two ways:
+
+    1) LOCAL BRIDGE  – serves the report on http://127.0.0.1:8765 so the
+       dashboard on THIS PC can pull it automatically ("Pull from this PC").
+    2) CLIPBOARD     – copies a report code you can paste into the dashboard
+       on ANY device ("Paste report").
+
+  Run it (Admin recommended, not required):
+      irm https://www.linearit.co/device/scan.ps1 | iex
+
+  It installs nothing, changes nothing, and only listens on loopback.
+  Press Ctrl+C to close when you're done.
+  ==========================================================================
+#>
+
+$ErrorActionPreference = 'SilentlyContinue'
+$Port          = 8765
+$BridgeSeconds = 300
+$SchemaVersion = 'linear-device/1'
+
+function Test-Admin {
+  try { return ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()
+    ).IsInRole([Security.Principal.WindowsBuiltinRole]::Administrator) } catch { return $false }
+}
+$IsAdmin = Test-Admin
+
+Write-Host ""
+Write-Host "  Linear IT — Device Deep Scan" -ForegroundColor Cyan
+Write-Host "  ---------------------------------------------" -ForegroundColor DarkGray
+Write-Host ("  Admin mode : {0}" -f $(if($IsAdmin){'Yes'}else{'No (a few security fields will be skipped)'}))
+Write-Host "  Collecting system information..." -ForegroundColor DarkGray
+
+# ---- helpers ----------------------------------------------------------------
+function GB($bytes){ if($bytes){ [math]::Round(($bytes/1GB),1) } else { $null } }
+
+# ---- OS / computer ----------------------------------------------------------
+$os  = Get-CimInstance Win32_OperatingSystem
+$cs  = Get-CimInstance Win32_ComputerSystem
+$bios= Get-CimInstance Win32_BIOS
+$typeMap = @{1='Desktop';2='Laptop';3='Workstation';4='Enterprise Server';5='SOHO Server';6='Appliance PC';7='Performance Server';8='Maximum'}
+$boot = $os.LastBootUpTime
+$uptime = if($boot){ (New-TimeSpan -Start $boot -End (Get-Date)) } else { $null }
+
+$computer = [ordered]@{
+  name         = $env:COMPUTERNAME
+  domain       = $cs.Domain
+  partOfDomain = [bool]$cs.PartOfDomain
+  manufacturer = $cs.Manufacturer
+  model        = $cs.Model
+  type         = $typeMap[[int]$cs.PCSystemType]
+  serial       = $bios.SerialNumber
+}
+$osInfo = [ordered]@{
+  caption   = $os.Caption
+  version   = $os.Version
+  build     = $os.BuildNumber
+  arch      = $os.OSArchitecture
+  installed = if($os.InstallDate){ $os.InstallDate.ToString('yyyy-MM-dd') } else { $null }
+  lastBoot  = if($boot){ $boot.ToString('o') } else { $null }
+  uptimeSec = if($uptime){ [int]$uptime.TotalSeconds } else { $null }
+}
+
+# ---- CPU --------------------------------------------------------------------
+$cpu = Get-CimInstance Win32_Processor | Select-Object -First 1
+$cpuInfo = [ordered]@{
+  name        = ($cpu.Name -replace '\s+',' ').Trim()
+  cores       = [int]$cpu.NumberOfCores
+  logical     = [int]$cpu.NumberOfLogicalProcessors
+  maxClockMhz = [int]$cpu.MaxClockSpeed
+}
+
+# ---- RAM --------------------------------------------------------------------
+$modules = @(Get-CimInstance Win32_PhysicalMemory | ForEach-Object {
+  [ordered]@{ sizeGB=(GB $_.Capacity); speedMhz=[int]$_.Speed; manufacturer=($_.Manufacturer).Trim() }
+})
+$ramArray = Get-CimInstance Win32_PhysicalMemoryArray | Select-Object -First 1
+$ramInfo = [ordered]@{
+  totalGB    = GB $cs.TotalPhysicalMemory
+  modules    = $modules
+  slotsUsed  = $modules.Count
+  slotsTotal = if($ramArray){ [int]$ramArray.MemoryDevices } else { $null }
+}
+
+# ---- Disks ------------------------------------------------------------------
+$disks = @(Get-CimInstance Win32_LogicalDisk -Filter 'DriveType=3' | ForEach-Object {
+  [ordered]@{
+    drive  = $_.DeviceID
+    label  = $_.VolumeName
+    fsType = $_.FileSystem
+    sizeGB = GB $_.Size
+    freeGB = GB $_.FreeSpace
+    usedPct= if($_.Size){ [int][math]::Round((($_.Size-$_.FreeSpace)/$_.Size)*100) } else { $null }
+  }
+})
+
+# ---- Users (admins vs standard) --------------------------------------------
+$adminNames = @()
+try {
+  $adminGroup = Get-LocalGroup -SID 'S-1-5-32-544'       # built-in Administrators, SID is locale-proof
+  $adminNames = @(Get-LocalGroupMember -Group $adminGroup.Name | ForEach-Object {
+    ($_.Name -split '\\')[-1] })
+} catch {}
+$localUsers = @(Get-LocalUser | Where-Object { $_.Enabled } | Select-Object -ExpandProperty Name)
+$standard = @($localUsers | Where-Object { $adminNames -notcontains $_ })
+$users = [ordered]@{
+  current       = "$env:USERDOMAIN\$env:USERNAME"
+  adminCount    = @($adminNames).Count
+  standardCount = @($standard).Count
+  admins        = @($adminNames | Select-Object -Unique)
+  standard      = @($standard | Select-Object -Unique)
+}
+
+# ---- Installed apps ---------------------------------------------------------
+$uninstallKeys = @(
+  'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*',
+  'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*',
+  'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*'
+)
+$appsRaw = foreach($k in $uninstallKeys){
+  Get-ItemProperty $k | Where-Object { $_.DisplayName -and -not $_.SystemComponent -and -not $_.ReleaseType } |
+    Select-Object DisplayName, DisplayVersion, Publisher
+}
+$apps = @($appsRaw | Sort-Object DisplayName -Unique | ForEach-Object {
+  [ordered]@{ name=$_.DisplayName; version=$_.DisplayVersion; publisher=$_.Publisher }
+})
+
+# ---- Installed content filter (the reliable check!) -------------------------
+$filterMap = @{
+  'Techloq'='Techloq'; 'NetSpark'='Netspark'; 'Netspark'='Netspark'; 'NetFree'='NetFree';
+  'Net Free'='NetFree'; 'Geder'='Geder'; 'Meshimer'='Meshimer'; 'Gentech'='Gentech';
+  'Nativ'='Nativ'; 'MBSmart'='MBSmart'; 'MB Smart'='MBSmart'; 'Bark'='Bark'; 'Qustodio'='Qustodio';
+  'Circle'='Circle'; 'Technology Awareness'='TAG'; 'Livigent'='Livigent'; 'K9 Web'='K9'
+}
+$svc = @(Get-CimInstance Win32_Service | Select-Object -ExpandProperty DisplayName)
+$haystack = @($apps.name) + $svc
+$filters = @()
+foreach($needle in $filterMap.Keys){
+  if($haystack | Where-Object { $_ -match [regex]::Escape($needle) }){ $filters += $filterMap[$needle] }
+}
+$filters = @($filters | Select-Object -Unique)
+
+# ---- Security (admin-only bits are best-effort) -----------------------------
+$security = [ordered]@{}
+try { $av = Get-CimInstance -Namespace 'root/SecurityCenter2' -Class AntiVirusProduct
+      $security.antivirus = @($av | Select-Object -ExpandProperty displayName -Unique) } catch {}
+try { $fw = Get-NetFirewallProfile
+      $security.firewall = if(($fw | Where-Object Enabled -eq $true).Count){ 'On' } else { 'Off' } } catch {}
+if($IsAdmin){
+  try { $bl = Get-BitLockerVolume -MountPoint $env:SystemDrive
+        $security.bitlocker = "$($bl.VolumeStatus) ($($bl.ProtectionStatus))" } catch {}
+}
+
+# ---- Network ----------------------------------------------------------------
+$net = @(Get-CimInstance Win32_NetworkAdapterConfiguration -Filter 'IPEnabled=true' | ForEach-Object {
+  [ordered]@{ name=$_.Description; ip=@($_.IPAddress | Where-Object { $_ -notmatch ':' })[0]; mac=$_.MACAddress }
+})
+
+# ---- Assemble ---------------------------------------------------------------
+$report = [ordered]@{
+  schema    = $SchemaVersion
+  generated = (Get-Date).ToUniversalTime().ToString('o')
+  admin     = $IsAdmin
+  computer  = $computer
+  os        = $osInfo
+  cpu       = $cpuInfo
+  ram       = $ramInfo
+  disks     = $disks
+  users     = $users
+  apps      = [ordered]@{ count=@($apps).Count; list=$apps }
+  filters   = $filters
+  security  = $security
+  network   = $net
+}
+
+$json    = $report | ConvertTo-Json -Depth 8 -Compress
+$pretty  = $report | ConvertTo-Json -Depth 8
+
+# save + clipboard
+$outFile = Join-Path ([Environment]::GetFolderPath('Desktop')) 'LinearDevice-Report.json'
+try { $pretty | Set-Content -Path $outFile -Encoding UTF8 } catch {}
+try { Set-Clipboard -Value $json } catch {}
+
+Write-Host ""
+Write-Host "  Done. Summary:" -ForegroundColor Green
+Write-Host ("    Computer : {0}  ({1} {2})" -f $computer.name,$computer.manufacturer,$computer.model)
+Write-Host ("    OS       : {0}  build {1}" -f $osInfo.caption,$osInfo.build)
+Write-Host ("    CPU      : {0}  ({1} cores, {2} MHz)" -f $cpuInfo.name,$cpuInfo.cores,$cpuInfo.maxClockMhz)
+Write-Host ("    RAM      : {0} GB in {1} slot(s)" -f $ramInfo.totalGB,$ramInfo.slotsUsed)
+Write-Host ("    Disks    : {0}" -f (($disks | ForEach-Object { "$($_.drive) $($_.freeGB)/$($_.sizeGB) GB free" }) -join ', '))
+Write-Host ("    Users    : {0} admin / {1} standard" -f $users.adminCount,$users.standardCount)
+Write-Host ("    Apps     : {0} installed" -f $apps.Count)
+Write-Host ("    Filter   : {0}" -f $(if($filters.Count){ $filters -join ', ' }else{ 'none detected' }))
+Write-Host ""
+Write-Host "  Report copied to your clipboard and saved to:" -ForegroundColor Yellow
+Write-Host ("    {0}" -f $outFile)
+Write-Host ""
+Write-Host "  NEXT: on device.linearit.co, open the 'Full System Scan' card and either" -ForegroundColor Cyan
+Write-Host "        - click 'Pull from this PC'  (keep this window open), or" -ForegroundColor Cyan
+Write-Host "        - click 'Paste report' and paste (Ctrl+V)." -ForegroundColor Cyan
+Write-Host ""
+
+# ---- Local bridge (raw loopback HTTP, no admin / no firewall prompt) --------
+$bodyBytes = [System.Text.Encoding]::UTF8.GetBytes($json)
+function Send-Response($stream,[int]$status,[byte[]]$payload){
+  $reason = if($status -eq 204){'No Content'} else {'OK'}
+  $hdr = @(
+    "HTTP/1.1 $status $reason",
+    "Access-Control-Allow-Origin: *",
+    "Access-Control-Allow-Private-Network: true",
+    "Access-Control-Allow-Methods: GET, OPTIONS",
+    "Access-Control-Allow-Headers: *",
+    "Cache-Control: no-store",
+    "Content-Type: application/json; charset=utf-8",
+    ("Content-Length: {0}" -f $(if($payload){$payload.Length}else{0})),
+    "Connection: close"
+  ) -join "`r`n"
+  $hb = [System.Text.Encoding]::UTF8.GetBytes($hdr + "`r`n`r`n")
+  $stream.Write($hb,0,$hb.Length)
+  if($payload -and $payload.Length){ $stream.Write($payload,0,$payload.Length) }
+  $stream.Flush()
+}
+
+try {
+  $tcp = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback,$Port)
+  $tcp.Start()
+  Write-Host ("  Bridge listening on http://127.0.0.1:{0}  (open for {1} min — Ctrl+C to stop)" -f $Port,($BridgeSeconds/60)) -ForegroundColor Green
+  $deadline = (Get-Date).AddSeconds($BridgeSeconds)
+  while((Get-Date) -lt $deadline){
+    if($tcp.Pending()){
+      $client = $tcp.AcceptTcpClient()
+      try{
+        $client.ReceiveTimeout = 1500; $client.SendTimeout = 3000
+        $ns = $client.GetStream()
+        Start-Sleep -Milliseconds 40
+        $buf = New-Object byte[] 4096; $n = 0
+        if($ns.DataAvailable){ $n = $ns.Read($buf,0,$buf.Length) }
+        $method = if($n){ (([System.Text.Encoding]::ASCII.GetString($buf,0,$n)) -split '\s+')[0] } else { 'GET' }
+        if($method -eq 'OPTIONS'){ Send-Response $ns 204 $null }
+        else { Send-Response $ns 200 $bodyBytes; Write-Host "  -> Report delivered to the dashboard." -ForegroundColor Green }
+      } catch {} finally { $client.Close() }
+    } else { Start-Sleep -Milliseconds 150 }
+  }
+  $tcp.Stop()
+  Write-Host "  Bridge closed. (The clipboard copy still works — use 'Paste report'.)" -ForegroundColor DarkGray
+} catch {
+  Write-Host ("  Could not start the local bridge ({0}). Use 'Paste report' instead." -f $_.Exception.Message) -ForegroundColor Yellow
+}


### PR DESCRIPTION
Lets you fill the **agent-only fields** on computers that don't have the NinjaOne agent — no install.

## `device/scan.ps1`
A no-install PowerShell script the tech runs on the target PC (Admin recommended, not required):
```
irm https://www.linearit.co/device/scan.ps1 | iex
```
Collects what browsers can't see: installed apps, **admin vs. standard local users**, real disk size/free, **OS uptime**, CPU model + **clock speed**, RAM modules, make/model/serial, security posture (AV/firewall/BitLocker), and — reliably — any **installed content filter** (Techloq/Netspark/NetFree/Geder/Meshimer/…). Installs nothing; listens only on loopback.

## Dashboard "Full System Scan" card
Ingests the report two ways:
- **Pull from this PC** — fetches the script's loopback bridge (`127.0.0.1:8765`, with CORS + Private-Network-Access headers) → auto-fills when the script and page run on the same machine.
- **Paste report** — paste the JSON the script copies to your clipboard → works from any device (run on the client's PC, paste on your phone).

`applyScan()` flips the **Users / Installed Apps / Storage / Uptime / CPU / RAM / OS / Content Filter** cards from "Agent required" to real values, and folds AV/firewall/BitLocker into the environment card.

## Validation
Headless Chromium confirms a pasted report fills every card correctly (2 admin/3 standard, app count, real disk free, `2d 9h` uptime, `2.90 GHz` clock, 16 GB RAM, Techloq as Installed, make/model/serial). Also verified the **Windows PowerShell 5.1 single-element-array quirk** (one disk/filter serialized as an object) is normalized. Full idle→run→send flow still passes.

`device.linearit.co` proxies the page, so it updates automatically after merge (≤5 min cache); `scan.ps1` is served from `/device/scan.ps1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N1XzF36MJdXMsqyFT5XJcM

---
_Generated by [Claude Code](https://claude.ai/code/session_01N1XzF36MJdXMsqyFT5XJcM)_