### PR TITLE
Fix scan.ps1 duplicate hashtable key (blocked the script from running)

### DIFF
--- a/device/scan.ps1
+++ b/device/scan.ps1
@@ -132,9 +132,9 @@ $apps = @($appsRaw | Sort-Object DisplayName -Unique | ForEach-Object {
 
 # ---- Installed content filter (the reliable check!) -------------------------
 $filterMap = @{
-  'Techloq'='Techloq'; 'NetSpark'='Netspark'; 'Netspark'='Netspark'; 'NetFree'='NetFree';
-  'Net Free'='NetFree'; 'Geder'='Geder'; 'Meshimer'='Meshimer'; 'Gentech'='Gentech';
-  'Nativ'='Nativ'; 'MBSmart'='MBSmart'; 'MB Smart'='MBSmart'; 'Bark'='Bark'; 'Qustodio'='Qustodio';
+  'Techloq'='Techloq'; 'Netspark'='Netspark'; 'NetFree'='NetFree'; 'Net Free'='NetFree';
+  'Geder'='Geder'; 'Meshimer'='Meshimer'; 'Gentech'='Gentech'; 'Nativ'='Nativ';
+  'MBSmart'='MBSmart'; 'MB Smart'='MBSmart'; 'Bark'='Bark'; 'Qustodio'='Qustodio';
   'Circle'='Circle'; 'Technology Awareness'='TAG'; 'Livigent'='Livigent'; 'K9 Web'='K9'
 }
 $svc = @(Get-CimInstance Win32_Service | Select-Object -ExpandProperty DisplayName)


### PR DESCRIPTION
PowerShell hashtable keys are case-insensitive, so `'NetSpark'` and `'Netspark'` in the filter-detection map collided and threw `DuplicateKeyInHashLiteral`, aborting the whole script at parse time. Removed the duplicate. Verified the rest of the script parses cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N1XzF36MJdXMsqyFT5XJcM

---
_Generated by [Claude Code](https://claude.ai/code/session_01N1XzF36MJdXMsqyFT5XJcM)_