### PR TITLE
Add zero-knowledge password manager for clients (/vault)

### DIFF
--- a/vault-worker/.gitignore
+++ b/vault-worker/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+.wrangler/
+dist/
+*.log
+.dev.vars

--- a/vault-worker/package.json
+++ b/vault-worker/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "linear-vault",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Cloudflare Worker backend for the Linear IT password manager at vault.linearit.co (zero-knowledge; stores only ciphertext).",
+  "scripts": {
+    "deploy": "wrangler deploy",
+    "dev": "wrangler dev",
+    "tail": "wrangler tail"
+  },
+  "devDependencies": {
+    "wrangler": "^3.90.0"
+  }
+}

--- a/vault-worker/src/index.js
+++ b/vault-worker/src/index.js
@@ -1,0 +1,661 @@
+/**
+ * Linear Vault — vault.linearit.co
+ * =============================================================================
+ * Zero-knowledge password manager backend for Linear IT's clients.
+ *
+ * WHAT "ZERO-KNOWLEDGE" MEANS HERE
+ * --------------------------------
+ * A client's master password never leaves their browser. The browser uses it to
+ * derive an encryption key (PBKDF2) and encrypts every vault entry (AES-256-GCM)
+ * BEFORE sending it here. This Worker only ever sees and stores *ciphertext* plus
+ * a peppered hash used to authenticate. Nobody with access to this Worker, this
+ * database, or Cloudflare can read a client's saved passwords — only the client,
+ * with their master password, can. (The trade-off: a forgotten master password
+ * cannot be recovered; an admin can only reset the account to empty.)
+ *
+ * TWO FACTORS TO SIGN IN
+ * ----------------------
+ *   1. Master password  (something you know — proves you can decrypt the vault)
+ *   2. Email MFA code    (something you have — a 6-digit code sent via Resend)
+ *
+ * WHO CAN HAVE AN ACCOUNT
+ * -----------------------
+ * Admin-approved only. An email must be on the `clients` allowlist (added by an
+ * admin) before it can register. Admins are the addresses in the ADMIN_EMAILS
+ * secret; they sign in with email + MFA only (no vault of their own) to manage
+ * the client list.
+ *
+ * ROUTES
+ *   Non-/api paths            -> reverse-proxied from the GitHub Pages app
+ *                                (APP_ORIGIN + APP_PATH), so vault.linearit.co
+ *                                shows the same app as www.linearit.co/vault/.
+ *   POST /api/auth/start       -> {authorized, registered, admin, salt?, iters?}
+ *   POST /api/auth/code        -> emails a one-time MFA code (register / admin)
+ *   POST /api/auth/register    -> create account (approved + not yet registered)
+ *   POST /api/auth/login       -> phase 1 (no code): verify master password,
+ *                                 email a code, return {mfa:true};
+ *                                 phase 2 (with code): -> session token + vault
+ *   GET  /api/vault            -> (auth) fetch encrypted vault blob
+ *   PUT  /api/vault            -> (auth) save encrypted vault blob (optimistic)
+ *   POST /api/account/rekey    -> (auth) change master password (re-wrap key)
+ *   POST /api/admin/login      -> admin sign in (email + code)
+ *   GET  /api/admin/clients    -> (admin) list allowlisted clients
+ *   POST /api/admin/clients    -> (admin) approve an email
+ *   DELETE /api/admin/clients  -> (admin) revoke an email (and delete its vault)
+ *   POST /api/admin/reset      -> (admin) reset a client to empty (they re-setup)
+ *   GET  /api/health           -> "ok"
+ *
+ * ENV (all secrets except the [vars] in wrangler.toml)
+ *   DB               D1 database binding (required)
+ *   AUTH_SECRET      long random string — pepper for hashes, signs session tokens
+ *   RESEND_API_KEY   send MFA email via Resend  (same key used by linear-chat)
+ *   EMAIL_FROM       From: address, e.g.  Linear IT <alert@linearit.co>
+ *   ADMIN_EMAILS     comma-separated admin addresses
+ *   ALLOW_ORIGIN     CORS origin for the API (default https://www.linearit.co)
+ *   APP_ORIGIN       where the app is hosted (default https://www.linearit.co)
+ *   APP_PATH         path of the app on that origin (default /vault/)
+ *   DEV_MODE = "1"   return the MFA code in the API response (LOCAL TESTING ONLY)
+ * =============================================================================
+ */
+
+const TOKEN_TTL_MS = 15 * 60 * 1000;   // session token lifetime (sliding; re-issued on each authed call)
+const CODE_TTL_MS = 10 * 60 * 1000;    // MFA code lifetime
+const CODE_RESEND_MS = 45 * 1000;      // min gap between MFA emails to one address
+const MAX_CODE_ATTEMPTS = 5;           // wrong MFA codes before a code is burned
+const MAX_PW_FAILS = 8;                // wrong master-password tries before lockout
+const PW_LOCK_MS = 15 * 60 * 1000;     // lockout duration after too many pw fails
+const DEFAULT_ITERS = 310000;          // PBKDF2 iterations the client should use
+
+export default {
+  async fetch(request, env, ctx) {
+    const url = new URL(request.url);
+    const p = url.pathname;
+    const method = request.method;
+
+    if (method === "OPTIONS") return cors(request, env, new Response(null, { status: 204 }));
+
+    try {
+      if (p === "/api/health") return cors(request, env, new Response("ok", { status: 200 }));
+      if (p.startsWith("/api/")) {
+        return cors(request, env, await handleApi(request, env, url, p, method));
+      }
+      // Everything else: serve the app by reverse-proxying the GitHub Pages copy.
+      return proxyApp(request, env, url, method);
+    } catch (err) {
+      const status = (err && err.status) || 500;
+      return cors(request, env, json({ error: String((err && err.message) || err) }, status));
+    }
+  },
+};
+
+/* ============================================================
+ * API router
+ * ============================================================ */
+async function handleApi(request, env, url, p, method) {
+  await ensureSchema(env);
+
+  if (p === "/api/auth/start" && method === "POST") return authStart(request, env);
+  if (p === "/api/auth/code" && method === "POST") return authCode(request, env);
+  if (p === "/api/auth/register" && method === "POST") return authRegister(request, env);
+  if (p === "/api/auth/login" && method === "POST") return authLogin(request, env);
+
+  if (p === "/api/vault" && method === "GET") return vaultGet(request, env);
+  if (p === "/api/vault" && method === "PUT") return vaultPut(request, env);
+  if (p === "/api/account/rekey" && method === "POST") return accountRekey(request, env);
+
+  if (p === "/api/admin/login" && method === "POST") return adminLogin(request, env);
+  if (p === "/api/admin/clients" && method === "GET") return adminListClients(request, env);
+  if (p === "/api/admin/clients" && method === "POST") return adminAddClient(request, env);
+  if (p === "/api/admin/clients" && method === "DELETE") return adminRemoveClient(request, env);
+  if (p === "/api/admin/reset" && method === "POST") return adminResetClient(request, env);
+
+  return json({ error: "Not found" }, 404);
+}
+
+/* ============================================================
+ * Auth — start (tells the browser which path this email is on)
+ * ============================================================ */
+async function authStart(request, env) {
+  const body = await readBody(request);
+  const email = normEmail(body.email);
+  if (!validEmail(email)) return json({ error: "Enter a valid email address." }, 400);
+
+  const admin = isAdminEmail(env, email);
+  const account = await env.DB.prepare("SELECT salt, iters FROM accounts WHERE email=?").bind(email).first();
+  const approved = !!(await env.DB.prepare("SELECT 1 FROM clients WHERE email=?").bind(email).first());
+
+  if (account) {
+    // Registered client — return its salt/iters so the browser can derive keys.
+    return json({ authorized: true, registered: true, admin, salt: account.salt, iters: Number(account.iters) });
+  }
+  if (admin) return json({ authorized: true, registered: false, admin: true });
+  if (approved) return json({ authorized: true, registered: false, admin: false, iters: DEFAULT_ITERS });
+  return json({ authorized: false, registered: false, admin: false });
+}
+
+/* ============================================================
+ * Auth — send a one-time MFA code by email (purpose-scoped)
+ * purpose: "register" (approved, new client) | "admin". Login codes are sent
+ * from /api/auth/login instead, only after the master password checks out.
+ * ============================================================ */
+async function authCode(request, env) {
+  const body = await readBody(request);
+  const email = normEmail(body.email);
+  const purpose = String(body.purpose || "").trim();
+  if (!validEmail(email)) return json({ error: "Enter a valid email address." }, 400);
+  if (!["register", "admin"].includes(purpose)) return json({ error: "Bad request." }, 400);
+
+  // Authorize the request for the stated purpose before sending anything.
+  // (Login sends its own code from /api/auth/login, only after the master
+  // password is verified — so a wrong password never triggers an email.)
+  const admin = isAdminEmail(env, email);
+  const account = await env.DB.prepare("SELECT 1 FROM accounts WHERE email=?").bind(email).first();
+  const approved = !!(await env.DB.prepare("SELECT 1 FROM clients WHERE email=?").bind(email).first());
+
+  if (purpose === "admin" && !admin) return json({ error: "This email isn't an administrator." }, 403);
+  if (purpose === "register" && !(approved && !account)) {
+    if (account) return json({ error: "This email is already set up. Choose sign in instead." }, 409);
+    return json({ error: "This email isn't approved yet. Contact Linear IT." }, 403);
+  }
+
+  const r = await issueCode(env, email, purpose);
+  if (r.error) return json({ error: r.error }, r.status);
+  const out = { ok: true };
+  if (r.dev_code) out.dev_code = r.dev_code;
+  return json(out);
+}
+
+// Generate, store (peppered hash) and email a fresh code. Enforces a resend gap.
+// Returns { ok:true, dev_code? } or { error, status }.
+async function issueCode(env, email, purpose) {
+  const now = Date.now();
+  await env.DB.prepare("DELETE FROM login_codes WHERE expires_at < ?").bind(now).run();
+
+  const recent = await env.DB
+    .prepare("SELECT created_at FROM login_codes WHERE email=? AND consumed=0 ORDER BY id DESC LIMIT 1")
+    .bind(email).first();
+  if (recent && now - Number(recent.created_at) < CODE_RESEND_MS) {
+    return { error: "A code was just sent. Please wait a moment before requesting another.", status: 429 };
+  }
+
+  await env.DB.prepare("UPDATE login_codes SET consumed=1 WHERE email=? AND consumed=0").bind(email).run();
+
+  const code = genCode();
+  const codeHash = await hashCode(env, email, code);
+  await env.DB
+    .prepare("INSERT INTO login_codes (email, code_hash, purpose, expires_at, attempts, consumed, created_at) VALUES (?,?,?,?,0,0,?)")
+    .bind(email, codeHash, purpose, now + CODE_TTL_MS, now).run();
+
+  const sent = await sendCodeEmail(env, email, code);
+  if (env.DEV_MODE === "1") return { ok: true, dev_code: code };
+  if (!sent) return { error: "Couldn't send the email — email delivery isn't configured yet.", status: 502 };
+  return { ok: true };
+}
+
+// Verify (and burn) a fresh MFA code for the given email + purpose.
+// Returns { ok:true } or { error, status }.
+async function consumeCode(env, email, code, purpose) {
+  if (!/^\d{4,8}$/.test(String(code || ""))) return { error: "Invalid code.", status: 400 };
+  const now = Date.now();
+  const row = await env.DB
+    .prepare("SELECT * FROM login_codes WHERE email=? AND consumed=0 ORDER BY id DESC LIMIT 1")
+    .bind(email).first();
+  if (!row) return { error: "No active code. Request a new one.", status: 400 };
+  if (row.purpose !== purpose) return { error: "This code is for a different action.", status: 400 };
+  if (Number(row.expires_at) < now) return { error: "That code expired. Request a new one.", status: 400 };
+  if (Number(row.attempts) >= MAX_CODE_ATTEMPTS) {
+    await env.DB.prepare("UPDATE login_codes SET consumed=1 WHERE id=?").bind(row.id).run();
+    return { error: "Too many attempts. Request a new code.", status: 429 };
+  }
+  const hash = await hashCode(env, email, code);
+  if (!timingSafeEqual(hash, row.code_hash)) {
+    await env.DB.prepare("UPDATE login_codes SET attempts=attempts+1 WHERE id=?").bind(row.id).run();
+    return { error: "Incorrect code.", status: 401 };
+  }
+  await env.DB.prepare("UPDATE login_codes SET consumed=1 WHERE id=?").bind(row.id).run();
+  return { ok: true };
+}
+
+/* ============================================================
+ * Auth — register (approved email sets its master password)
+ * The browser sends only: its chosen salt/iters, an auth verifier (proof of the
+ * master password, NOT the key), the DEK wrapped by the master key, and the
+ * (empty) encrypted vault. The server stores ciphertext + a peppered hash.
+ * ============================================================ */
+async function authRegister(request, env) {
+  const body = await readBody(request);
+  const email = normEmail(body.email);
+  if (!validEmail(email)) return json({ error: "Enter a valid email address." }, 400);
+
+  const approved = !!(await env.DB.prepare("SELECT 1 FROM clients WHERE email=?").bind(email).first());
+  const exists = await env.DB.prepare("SELECT 1 FROM accounts WHERE email=?").bind(email).first();
+  if (!approved) return json({ error: "This email isn't approved yet. Contact Linear IT." }, 403);
+  if (exists) return json({ error: "This email is already set up." }, 409);
+
+  const cr = await consumeCode(env, email, body.code, "register");
+  if (cr.error) return json({ error: cr.error }, cr.status);
+
+  const salt = String(body.salt || "");
+  const iters = Number(body.iters || 0);
+  const authVerifier = String(body.auth_verifier || "");
+  const wrappedDek = String(body.wrapped_dek || "");
+  const vaultBlob = String(body.vault_blob || "");
+  if (!isB64(salt) || iters < 100000 || iters > 5000000 || !isB64(authVerifier) ||
+      !looksBlob(wrappedDek) || !looksBlob(vaultBlob)) {
+    return json({ error: "Malformed setup data." }, 400);
+  }
+
+  const now = Date.now();
+  const authHash = await hashVerifier(env, email, authVerifier);
+  await env.DB.prepare(
+    "INSERT INTO accounts (email, salt, iters, auth_hash, wrapped_dek, vault_blob, vault_ver, failed, locked_until, created_at, updated_at) " +
+    "VALUES (?,?,?,?,?,?,1,0,0,?,?)"
+  ).bind(email, salt, iters, authHash, wrappedDek, vaultBlob, now, now).run();
+
+  const token = await makeToken(env, { email, kind: "user" });
+  return json({ token, vault_ver: 1 });
+}
+
+/* ============================================================
+ * Auth — login. Two phases against this one endpoint:
+ *   Phase 1  {email, auth_verifier}          -> verify master password, then
+ *                                               email a code -> {mfa:true}
+ *   Phase 2  {email, auth_verifier, code}     -> verify password + code ->
+ *                                               session token + ciphertext
+ * The master password is always checked first, so a wrong password never emails
+ * a code and never burns the client's active code.
+ * ============================================================ */
+async function authLogin(request, env) {
+  const body = await readBody(request);
+  const email = normEmail(body.email);
+  const authVerifier = String(body.auth_verifier || "");
+  const hasCode = body.code !== undefined && body.code !== null && String(body.code) !== "";
+  if (!validEmail(email) || !isB64(authVerifier)) return json({ error: "Invalid email or password." }, 400);
+
+  const acct = await env.DB.prepare("SELECT * FROM accounts WHERE email=?").bind(email).first();
+  if (!acct) return json({ error: "Incorrect email or master password." }, 401);
+
+  const now = Date.now();
+  if (Number(acct.locked_until) > now) {
+    return json({ error: "Too many attempts. Try again in a few minutes." }, 429);
+  }
+
+  const expect = await hashVerifier(env, email, authVerifier);
+  if (!timingSafeEqual(expect, acct.auth_hash)) {
+    const failed = Number(acct.failed) + 1;
+    const lockUntil = failed >= MAX_PW_FAILS ? now + PW_LOCK_MS : 0;
+    await env.DB.prepare("UPDATE accounts SET failed=?, locked_until=? WHERE email=?")
+      .bind(failed >= MAX_PW_FAILS ? 0 : failed, lockUntil, email).run();
+    return json({ error: "Incorrect email or master password." }, 401);
+  }
+  // Password is correct — clear the fail counter either way.
+  await env.DB.prepare("UPDATE accounts SET failed=0, locked_until=0 WHERE email=?").bind(email).run();
+
+  // Phase 1: no code yet -> send one to the email (2nd factor).
+  if (!hasCode) {
+    const r = await issueCode(env, email, "login");
+    if (r.error) return json({ error: r.error }, r.status);
+    const out = { mfa: true };
+    if (r.dev_code) out.dev_code = r.dev_code;
+    return json(out);
+  }
+
+  // Phase 2: verify the emailed code, then hand over the encrypted vault.
+  const cr = await consumeCode(env, email, body.code, "login");
+  if (cr.error) return json({ error: cr.error }, cr.status);
+
+  const token = await makeToken(env, { email, kind: "user" });
+  return json({
+    token,
+    salt: acct.salt,
+    iters: Number(acct.iters),
+    wrapped_dek: acct.wrapped_dek,
+    vault_blob: acct.vault_blob,
+    vault_ver: Number(acct.vault_ver),
+  });
+}
+
+/* ============================================================
+ * Vault — fetch / save encrypted blob (auth required)
+ * ============================================================ */
+async function vaultGet(request, env) {
+  const claims = await requireUser(request, env);
+  const acct = await env.DB.prepare("SELECT wrapped_dek, vault_blob, vault_ver FROM accounts WHERE email=?")
+    .bind(claims.email).first();
+  if (!acct) return json({ error: "Account not found." }, 404);
+  return json({
+    token: await makeToken(env, { email: claims.email, kind: "user" }),
+    wrapped_dek: acct.wrapped_dek,
+    vault_blob: acct.vault_blob,
+    vault_ver: Number(acct.vault_ver),
+  });
+}
+
+async function vaultPut(request, env) {
+  const claims = await requireUser(request, env);
+  const body = await readBody(request);
+  const blob = String(body.vault_blob || "");
+  const baseVer = Number(body.base_ver);
+  if (!looksBlob(blob)) return json({ error: "Malformed vault data." }, 400);
+  if (blob.length > 5_000_000) return json({ error: "Vault is too large." }, 413);
+
+  const acct = await env.DB.prepare("SELECT vault_ver FROM accounts WHERE email=?").bind(claims.email).first();
+  if (!acct) return json({ error: "Account not found." }, 404);
+  if (Number.isFinite(baseVer) && baseVer !== Number(acct.vault_ver)) {
+    // Someone saved from another device since this client loaded — avoid clobber.
+    return json({ error: "conflict", vault_ver: Number(acct.vault_ver) }, 409);
+  }
+  const next = Number(acct.vault_ver) + 1;
+  await env.DB.prepare("UPDATE accounts SET vault_blob=?, vault_ver=?, updated_at=? WHERE email=?")
+    .bind(blob, next, Date.now(), claims.email).run();
+  return json({ token: await makeToken(env, { email: claims.email, kind: "user" }), vault_ver: next });
+}
+
+/* ============================================================
+ * Account — change master password (re-wrap the vault key; no re-encrypt)
+ * ============================================================ */
+async function accountRekey(request, env) {
+  const claims = await requireUser(request, env);
+  const body = await readBody(request);
+  const salt = String(body.salt || "");
+  const iters = Number(body.iters || 0);
+  const authVerifier = String(body.auth_verifier || "");
+  const wrappedDek = String(body.wrapped_dek || "");
+  if (!isB64(salt) || iters < 100000 || iters > 5000000 || !isB64(authVerifier) || !looksBlob(wrappedDek)) {
+    return json({ error: "Malformed data." }, 400);
+  }
+  const authHash = await hashVerifier(env, claims.email, authVerifier);
+  const res = await env.DB.prepare(
+    "UPDATE accounts SET salt=?, iters=?, auth_hash=?, wrapped_dek=?, failed=0, locked_until=0, updated_at=? WHERE email=?"
+  ).bind(salt, iters, authHash, wrappedDek, Date.now(), claims.email).run();
+  if (!res.meta || res.meta.changes === 0) return json({ error: "Account not found." }, 404);
+  return json({ token: await makeToken(env, { email: claims.email, kind: "user" }), ok: true });
+}
+
+/* ============================================================
+ * Admin — sign in (email + MFA only) and manage the client allowlist
+ * ============================================================ */
+async function adminLogin(request, env) {
+  const body = await readBody(request);
+  const email = normEmail(body.email);
+  if (!isAdminEmail(env, email)) return json({ error: "This email isn't an administrator." }, 403);
+  const cr = await consumeCode(env, email, body.code, "admin");
+  if (cr.error) return json({ error: cr.error }, cr.status);
+  const token = await makeToken(env, { email, kind: "admin" });
+  return json({ token });
+}
+
+async function adminListClients(request, env) {
+  const claims = await requireAdmin(request, env);
+  const rows = (await env.DB.prepare(
+    "SELECT c.email AS email, c.created_at AS created_at, " +
+    "(SELECT 1 FROM accounts a WHERE a.email=c.email) AS registered, " +
+    "(SELECT updated_at FROM accounts a WHERE a.email=c.email) AS last_saved " +
+    "FROM clients c ORDER BY c.email"
+  ).all()).results || [];
+  const clients = rows.map((r) => ({
+    email: r.email,
+    registered: !!r.registered,
+    created_at: Number(r.created_at) || 0,
+    last_saved: Number(r.last_saved) || 0,
+  }));
+  return json({ token: await makeToken(env, { email: claims.email, kind: "admin" }), clients });
+}
+
+async function adminAddClient(request, env) {
+  const claims = await requireAdmin(request, env);
+  const body = await readBody(request);
+  const email = normEmail(body.email);
+  if (!validEmail(email)) return json({ error: "Enter a valid email address." }, 400);
+  await env.DB.prepare("INSERT OR IGNORE INTO clients (email, added_by, created_at) VALUES (?,?,?)")
+    .bind(email, claims.email, Date.now()).run();
+  return json({ token: await makeToken(env, { email: claims.email, kind: "admin" }), ok: true });
+}
+
+async function adminRemoveClient(request, env) {
+  const claims = await requireAdmin(request, env);
+  const body = await readBody(request);
+  const email = normEmail(body.email);
+  if (!validEmail(email)) return json({ error: "Enter a valid email address." }, 400);
+  // Revoke = remove from allowlist AND delete their (encrypted) vault entirely.
+  await env.DB.prepare("DELETE FROM accounts WHERE email=?").bind(email).run();
+  await env.DB.prepare("DELETE FROM clients WHERE email=?").bind(email).run();
+  await env.DB.prepare("DELETE FROM login_codes WHERE email=?").bind(email).run();
+  return json({ token: await makeToken(env, { email: claims.email, kind: "admin" }), ok: true });
+}
+
+async function adminResetClient(request, env) {
+  const claims = await requireAdmin(request, env);
+  const body = await readBody(request);
+  const email = normEmail(body.email);
+  if (!validEmail(email)) return json({ error: "Enter a valid email address." }, 400);
+  // Reset = delete the account (encrypted vault) but keep them on the allowlist,
+  // so the client can set a brand-new master password and start fresh.
+  await env.DB.prepare("DELETE FROM accounts WHERE email=?").bind(email).run();
+  await env.DB.prepare("DELETE FROM login_codes WHERE email=?").bind(email).run();
+  return json({ token: await makeToken(env, { email: claims.email, kind: "admin" }), ok: true });
+}
+
+/* ============================================================
+ * Auth token helpers (HMAC-signed, sliding expiry)
+ * ============================================================ */
+async function requireUser(request, env) {
+  const c = await authClaims(request, env);
+  if (!c || c.kind !== "user") throw httpError("Please sign in again.", 401);
+  return c;
+}
+async function requireAdmin(request, env) {
+  const c = await authClaims(request, env);
+  if (!c || c.kind !== "admin" || !isAdminEmail(env, c.email)) throw httpError("Admin sign-in required.", 401);
+  return c;
+}
+async function makeToken(env, claims) {
+  const payload = b64urlStr(JSON.stringify(Object.assign({ exp: Date.now() + TOKEN_TTL_MS }, claims)));
+  return payload + "." + (await hmacSign(env, payload));
+}
+async function authClaims(request, env) {
+  const token = (request.headers.get("Authorization") || "").replace(/^Bearer\s+/i, "").trim();
+  if (!token) return null;
+  const [payload, sig] = token.split(".");
+  if (!payload || !sig) return null;
+  if (!timingSafeEqual(await hmacSign(env, payload), sig)) return null;
+  try {
+    const claims = JSON.parse(b64urlDecodeToStr(payload));
+    if (!claims.exp || claims.exp < Date.now() || !claims.email) return null;
+    return claims;
+  } catch (_) { return null; }
+}
+
+/* ============================================================
+ * Crypto / encoding
+ * ============================================================ */
+async function hmacSign(env, data) {
+  const key = await crypto.subtle.importKey(
+    "raw", new TextEncoder().encode(env.AUTH_SECRET || "dev-secret"),
+    { name: "HMAC", hash: "SHA-256" }, false, ["sign"]
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(data));
+  return b64url(sig);
+}
+async function sha256Hex(str) {
+  const buf = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(str));
+  return [...new Uint8Array(buf)].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+// Peppered hash of an emailed code (so a DB leak doesn't reveal live codes).
+function hashCode(env, email, code) {
+  return sha256Hex((env.AUTH_SECRET || "dev-secret") + "|code|" + email + "|" + code);
+}
+// Peppered hash of the master-password auth verifier (never store it raw).
+function hashVerifier(env, email, verifier) {
+  return sha256Hex((env.AUTH_SECRET || "dev-secret") + "|verify|" + email + "|" + verifier);
+}
+function genCode() { return String(crypto.getRandomValues(new Uint32Array(1))[0] % 1000000).padStart(6, "0"); }
+function timingSafeEqual(a, b) {
+  if (typeof a !== "string" || typeof b !== "string" || a.length !== b.length) return false;
+  let r = 0;
+  for (let i = 0; i < a.length; i++) r |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return r === 0;
+}
+function b64url(bytes) {
+  const s = btoa(String.fromCharCode(...new Uint8Array(bytes)));
+  return s.replace(/=+$/, "").replace(/\+/g, "-").replace(/\//g, "_");
+}
+function b64urlStr(str) { return b64url(new TextEncoder().encode(str)); }
+function b64urlDecodeToStr(b64) {
+  let s = b64.replace(/-/g, "+").replace(/_/g, "/");
+  while (s.length % 4) s += "=";
+  const bin = atob(s);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return new TextDecoder().decode(bytes);
+}
+
+/* ============================================================
+ * Email (Resend) — same provider linear-chat uses
+ * ============================================================ */
+async function sendCodeEmail(env, email, code) {
+  return sendEmail(env, {
+    to: email,
+    subject: "Your Linear IT vault code: " + code,
+    text: "Your Linear IT password vault verification code is " + code +
+      "\n\nThis code expires in 10 minutes. If you didn't request it, you can ignore this email.",
+    html: codeEmailHtml(code),
+  });
+}
+function codeEmailHtml(code) {
+  return '<div style="font-family:system-ui,Segoe UI,Arial,sans-serif;max-width:440px;margin:auto;padding:24px">' +
+    '<h2 style="margin:0 0 4px;color:#111">Linear IT — Password Vault</h2>' +
+    '<p style="color:#444;margin:0 0 16px">Use this code to finish signing in:</p>' +
+    '<div style="font-size:34px;font-weight:700;letter-spacing:8px;background:#f3f4f6;border-radius:12px;padding:16px;text-align:center;color:#111">' + code + "</div>" +
+    '<p style="color:#888;font-size:13px;margin:16px 0 0">This code expires in 10 minutes. If you didn\'t request it, you can ignore this email — your vault stays locked.</p>' +
+    '<p style="color:#aab;font-size:12px;margin:14px 0 0">Linear IT · (845) 604-1462</p>' +
+    "</div>";
+}
+async function sendEmail(env, msg) {
+  try {
+    if (env.RESEND_API_KEY) {
+      const res = await fetch("https://api.resend.com/emails", {
+        method: "POST",
+        headers: { Authorization: "Bearer " + env.RESEND_API_KEY, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          from: env.EMAIL_FROM || "Linear IT <alert@linearit.co>",
+          to: [msg.to], subject: msg.subject, text: msg.text, html: msg.html,
+        }),
+      });
+      return res.ok;
+    }
+  } catch (_) { /* fall through */ }
+  return false;
+}
+
+/* ============================================================
+ * Reverse-proxy the app from GitHub Pages (so vault.linearit.co serves it)
+ * ============================================================ */
+async function proxyApp(request, env, url, method) {
+  if (method !== "GET" && method !== "HEAD") {
+    return new Response("Method Not Allowed", { status: 405, headers: { Allow: "GET, HEAD" } });
+  }
+  const origin = env.APP_ORIGIN || "https://www.linearit.co";
+  const appPath = env.APP_PATH || "/vault/";
+  const path = url.pathname === "/" ? appPath : url.pathname;
+  const target = origin + path + url.search;
+
+  let originResp;
+  try {
+    originResp = await fetch(target, {
+      method: "GET",
+      headers: { Accept: request.headers.get("Accept") || "*/*", "Accept-Encoding": "gzip" },
+      redirect: "follow",
+      cf: { cacheEverything: false, cacheTtl: 0 },
+    });
+  } catch (_) {
+    return new Response("Vault is briefly unavailable. Please try again in a moment.", {
+      status: 503, headers: { "content-type": "text/plain; charset=utf-8", "retry-after": "20" },
+    });
+  }
+  if (originResp.status === 404) return new Response("Not found", { status: 404 });
+
+  const headers = new Headers(originResp.headers);
+  headers.delete("set-cookie");
+  headers.delete("transfer-encoding");
+  headers.set("X-Content-Type-Options", "nosniff");
+  headers.set("X-Frame-Options", "DENY");
+  headers.set("Referrer-Policy", "no-referrer");
+  headers.set("Cache-Control", "no-store, must-revalidate");
+  headers.set("X-Served-By", "linear-vault");
+  const body = method === "HEAD" ? null : originResp.body;
+  return new Response(body, { status: originResp.status, statusText: originResp.statusText, headers });
+}
+
+/* ============================================================
+ * Small helpers
+ * ============================================================ */
+function normEmail(e) { return String(e || "").trim().toLowerCase(); }
+function validEmail(e) { return /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(e); }
+function isB64(s) { return typeof s === "string" && s.length > 0 && s.length < 100000 && /^[A-Za-z0-9+/=_-]+$/.test(s); }
+// An encrypted blob is transported as a compact JSON string {"iv":"..","ct":".."}.
+function looksBlob(s) {
+  if (typeof s !== "string" || s.length < 2 || s.length > 6_000_000) return false;
+  try { const o = JSON.parse(s); return !!o && typeof o.iv === "string" && typeof o.ct === "string"; }
+  catch (_) { return false; }
+}
+function adminEmailSet(env) {
+  return String(env.ADMIN_EMAILS || "").split(",").map((e) => normEmail(e)).filter(Boolean);
+}
+function isAdminEmail(env, email) { return adminEmailSet(env).includes(normEmail(email)); }
+function httpError(message, status) { const e = new Error(message); e.status = status; return e; }
+async function readBody(request) {
+  const ct = request.headers.get("content-type") || "";
+  if (ct.includes("application/json")) { try { return await request.json(); } catch (_) { return {}; } }
+  try { const fd = await request.formData(); return Object.fromEntries(fd.entries()); } catch (_) { return {}; }
+}
+const json = (obj, status = 200) =>
+  new Response(JSON.stringify(obj), { status, headers: { "Content-Type": "application/json" } });
+
+// CORS: allow the GitHub Pages app origin (and same-origin vault.linearit.co).
+function cors(request, env, res) {
+  const allowed = [
+    env.ALLOW_ORIGIN || "https://www.linearit.co",
+    "https://www.linearit.co",
+    "https://cftheitguy.github.io",
+    "https://vault.linearit.co",
+  ];
+  const origin = request.headers.get("Origin") || "";
+  const allow = allowed.includes(origin) ? origin : (env.ALLOW_ORIGIN || "https://www.linearit.co");
+  const h = new Headers(res.headers);
+  h.set("Access-Control-Allow-Origin", allow);
+  h.set("Access-Control-Allow-Methods", "GET,POST,PUT,DELETE,OPTIONS");
+  h.set("Access-Control-Allow-Headers", "Content-Type,Authorization");
+  h.set("Access-Control-Max-Age", "86400");
+  h.set("Vary", "Origin");
+  return new Response(res.body, { status: res.status, headers: h });
+}
+
+/* ============================================================
+ * Schema — created on first request (no manual migration step)
+ * ============================================================ */
+let schemaReady = false;
+async function ensureSchema(env) {
+  if (schemaReady) return;
+  await env.DB.batch([
+    env.DB.prepare(
+      "CREATE TABLE IF NOT EXISTS clients (" +
+      "email TEXT PRIMARY KEY, added_by TEXT, created_at INTEGER NOT NULL)"
+    ),
+    env.DB.prepare(
+      "CREATE TABLE IF NOT EXISTS accounts (" +
+      "email TEXT PRIMARY KEY, salt TEXT NOT NULL, iters INTEGER NOT NULL, auth_hash TEXT NOT NULL, " +
+      "wrapped_dek TEXT NOT NULL, vault_blob TEXT, vault_ver INTEGER NOT NULL DEFAULT 0, " +
+      "failed INTEGER NOT NULL DEFAULT 0, locked_until INTEGER NOT NULL DEFAULT 0, " +
+      "created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)"
+    ),
+    env.DB.prepare(
+      "CREATE TABLE IF NOT EXISTS login_codes (" +
+      "id INTEGER PRIMARY KEY AUTOINCREMENT, email TEXT NOT NULL, code_hash TEXT NOT NULL, " +
+      "purpose TEXT NOT NULL DEFAULT 'login', expires_at INTEGER NOT NULL, attempts INTEGER NOT NULL DEFAULT 0, " +
+      "consumed INTEGER NOT NULL DEFAULT 0, created_at INTEGER NOT NULL)"
+    ),
+    env.DB.prepare("CREATE INDEX IF NOT EXISTS idx_codes_email ON login_codes(email)"),
+  ]);
+  schemaReady = true;
+}

--- a/vault-worker/wrangler.toml
+++ b/vault-worker/wrangler.toml
@@ -1,0 +1,52 @@
+# Cloudflare Worker config for the Linear Vault (password manager) — vault.linearit.co
+# -----------------------------------------------------------------------------
+# This is a SEPARATE, isolated Worker from linear-chat and linear-device. It lives
+# in its own folder with its own config and shares NOTHING with the other Workers,
+# so it cannot affect chat.linearit.co or device.linearit.co.
+#
+# ---- ONE-TIME SETUP (run from this folder) ----------------------------------
+#   1. cd vault-worker && npm install
+#   2. npx wrangler d1 create linear_vault          # creates the database...
+#      ...then paste the printed database_id below into `database_id`.
+#   3. Set the encrypted secrets (they survive every deploy):
+#        npx wrangler secret put AUTH_SECRET      # any long random string (>=32 chars)
+#        npx wrangler secret put RESEND_API_KEY   # same key you already use for chat
+#        npx wrangler secret put EMAIL_FROM       # ->  Linear IT <alert@linearit.co>
+#        npx wrangler secret put ADMIN_EMAILS     # your email(s), comma-separated
+#   4. npx wrangler deploy
+#
+# That single `deploy` also creates the vault.linearit.co Custom Domain AND its DNS
+# record automatically in the linearit.co zone (because of custom_domain = true).
+# The database tables create themselves on first request — no schema step.
+#
+# Secrets are intentionally NOT in this file (public repo). AUTH_SECRET,
+# RESEND_API_KEY, EMAIL_FROM and ADMIN_EMAILS must stay as *encrypted Secrets* on
+# the Worker — those survive deploys; plaintext vars not listed here get wiped.
+
+name = "linear-vault"
+main = "src/index.js"
+compatibility_date = "2025-06-01"
+
+# Vanity hostname -> this Worker. Auto-provisions the Custom Domain + DNS on deploy.
+routes = [
+  { pattern = "vault.linearit.co", custom_domain = true }
+]
+
+# --- D1 database (accounts, encrypted vault blobs, client allowlist, MFA codes) ---
+# Run `npx wrangler d1 create linear_vault` and paste the returned id here.
+[[d1_databases]]
+binding = "DB"
+database_name = "linear_vault"
+database_id = "PASTE_YOUR_D1_DATABASE_ID_HERE"
+
+# Non-secret vars only. Keep AUTH_SECRET / RESEND_API_KEY / EMAIL_FROM / ADMIN_EMAILS
+# as encrypted Secrets (see setup above), NOT here.
+[vars]
+# CORS origin allowed to call this API. The app is served from the GitHub Pages
+# site, so the browser's Origin is https://www.linearit.co. Same-origin calls from
+# https://vault.linearit.co are always allowed too.
+ALLOW_ORIGIN = "https://www.linearit.co"
+# Where the front-end lives on the GitHub Pages site (this Worker reverse-proxies
+# it so vault.linearit.co shows the same app, with no second copy to maintain).
+APP_ORIGIN = "https://www.linearit.co"
+APP_PATH = "/vault/"

--- a/vault-worker/wrangler.toml
+++ b/vault-worker/wrangler.toml
@@ -37,7 +37,7 @@ routes = [
 [[d1_databases]]
 binding = "DB"
 database_name = "linear_vault"
-database_id = "PASTE_YOUR_D1_DATABASE_ID_HERE"
+database_id = "ca04bb5a-51bf-4895-b3fc-d6a7cfa08e9e"
 
 # Non-secret vars only. Keep AUTH_SECRET / RESEND_API_KEY / EMAIL_FROM / ADMIN_EMAILS
 # as encrypted Secrets (see setup above), NOT here.

--- a/vault/app.js
+++ b/vault/app.js
@@ -1,0 +1,779 @@
+/* =============================================================================
+ * Linear Vault — client app (vault.linearit.co / www.linearit.co/vault/)
+ * -----------------------------------------------------------------------------
+ * ZERO-KNOWLEDGE. The master password never leaves this browser. It is stretched
+ * with PBKDF2-SHA256 into a key-encryption key (KEK). A random 256-bit data key
+ * (DEK) actually encrypts the vault (AES-256-GCM); the DEK is wrapped by the KEK
+ * so changing the master password only re-wraps the DEK (no re-encrypt). The
+ * server only ever receives ciphertext + a separate "auth verifier" used to log
+ * in — never the KEK, DEK, or any plaintext.
+ *
+ * Nothing sensitive is persisted: the DEK and decrypted items live only in memory
+ * and are wiped on lock, sign-out, or 10 minutes of inactivity. Refreshing the
+ * page requires signing in again — by design.
+ * ============================================================================= */
+(function () {
+  "use strict";
+
+  /* ---- Anti-clickjacking: never allow this app to run inside a frame ---- */
+  if (window.top !== window.self) {
+    try { window.top.location = window.self.location; } catch (_) { document.documentElement.textContent = ""; }
+  }
+
+  /* ---- Config ---- */
+  // Served from GitHub Pages -> talk to the Worker; served by the Worker -> same-origin.
+  var API_BASE = location.hostname === "vault.linearit.co" ? "" : "https://vault.linearit.co";
+  var IDLE_MS = 10 * 60 * 1000;      // auto sign-out after 10 min idle
+  var IDLE_WARN_MS = 45 * 1000;      // warn this long before the cut-off
+  var DEFAULT_ITERS = 310000;        // PBKDF2 iterations for new/rekeyed accounts
+
+  var FOLDERS = [
+    { id: "pc", name: "PC", icon: "monitor" },
+    { id: "online", name: "Online Accounts", icon: "globe" },
+    { id: "passwords", name: "Passwords", icon: "key" },
+  ];
+  function folderName(id) { for (var i = 0; i < FOLDERS.length; i++) if (FOLDERS[i].id === id) return FOLDERS[i].name; return "Passwords"; }
+
+  /* ---- Runtime state (all cleared on lock) ---- */
+  var S = null;
+  function freshState() {
+    return {
+      token: null, email: "", mode: null,     // mode: 'login' | 'register' | 'admin'
+      kek: null, authVerifier: "",             // derived from master password (login/register in progress)
+      salt: "", iters: 0, wrappedDek: "",      // current account key material (kept to allow rekey)
+      dek: null, items: [], vaultVer: 0,       // decrypted vault (memory only)
+      folder: "pc", query: "", isAdmin: false, // UI
+    };
+  }
+  S = freshState();
+
+  /* ---- Tiny DOM helpers ---- */
+  function $(sel) { return document.querySelector(sel); }
+  function h(tag, attrs, kids) {
+    var e = document.createElement(tag);
+    if (attrs) for (var k in attrs) {
+      var v = attrs[k];
+      if (v == null) continue;
+      if (k === "class") e.className = v;
+      else if (k === "text") e.textContent = v;                 // safe: user data goes here
+      else if (k === "html") e.innerHTML = v;                   // ONLY trusted constant SVG
+      else if (k.slice(0, 2) === "on") e.addEventListener(k.slice(2), v);
+      else e.setAttribute(k, v);
+    }
+    if (kids != null) (Array.isArray(kids) ? kids : [kids]).forEach(function (c) {
+      if (c == null || c === false) return;
+      e.appendChild(typeof c === "string" ? document.createTextNode(c) : c);
+    });
+    return e;
+  }
+  var SCREENS = ["email", "password", "register", "code", "vault", "admin"];
+  function show(name) { SCREENS.forEach(function (s) { $("#screen-" + s).classList.toggle("hidden", s !== name); }); }
+
+  var toastTimer;
+  function toast(msg, kind) {
+    var t = $("#toast"); t.textContent = msg; t.className = "show " + (kind || "");
+    clearTimeout(toastTimer); toastTimer = setTimeout(function () { t.className = ""; }, 2600);
+  }
+
+  /* ---- Trusted inline icons (constants only) ---- */
+  var IC = {
+    monitor: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg>',
+    globe: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M3 12h18"/><path d="M12 3a15 15 0 0 1 4 9 15 15 0 0 1-4 9 15 15 0 0 1-4-9 15 15 0 0 1 4-9Z"/></svg>',
+    key: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="7.5" cy="15.5" r="4.5"/><path d="m10.8 12.2 8-8"/><path d="m16 5 3 3"/><path d="m19 2 3 3"/></svg>',
+    copy: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="12" height="12" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>',
+    eye: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7Z"/><circle cx="12" cy="12" r="3"/></svg>',
+    eyeoff: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9.9 4.2A11 11 0 0 1 12 4c7 0 11 8 11 8a18 18 0 0 1-2.2 3.2M6.1 6.1A18 18 0 0 0 1 12s4 8 11 8a11 11 0 0 0 5.9-1.7"/><path d="M9.9 9.9a3 3 0 0 0 4.2 4.2"/><path d="M1 1l22 22"/></svg>',
+    edit: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.1 2.1 0 0 1 3 3L12 15l-4 1 1-4Z"/></svg>',
+    trash: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2m2 0v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/></svg>',
+    ext: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/></svg>',
+    gen: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 2v6h-6"/><path d="M3 12a9 9 0 0 1 15-6.7L21 8"/><path d="M3 22v-6h6"/><path d="M21 12a9 9 0 0 1-15 6.7L3 16"/></svg>',
+    check: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>',
+  };
+  function icon(name) { return h("span", { html: IC[name] }); }
+
+  /* =========================================================================
+   * Crypto (Web Crypto only)
+   * ========================================================================= */
+  var enc = new TextEncoder(), dec = new TextDecoder();
+  function b64(buf) { var b = new Uint8Array(buf), s = "", i; for (i = 0; i < b.length; i++) s += String.fromCharCode(b[i]); return btoa(s); }
+  function unb64(str) { var bin = atob(str), u = new Uint8Array(bin.length), i; for (i = 0; i < bin.length; i++) u[i] = bin.charCodeAt(i); return u; }
+
+  // master password + salt -> { kek (AES-GCM key), authVerifier (b64 proof) }
+  async function deriveKeys(password, saltU8, iters) {
+    var base = await crypto.subtle.importKey("raw", enc.encode(password), "PBKDF2", false, ["deriveBits"]);
+    var bits = await crypto.subtle.deriveBits({ name: "PBKDF2", salt: saltU8, iterations: iters, hash: "SHA-256" }, base, 512);
+    var raw = new Uint8Array(bits);
+    var kekRaw = raw.slice(0, 32);       // first half -> encryption key (stays here)
+    var authRaw = raw.slice(32, 64);     // second half -> proof sent to the server
+    var kek = await crypto.subtle.importKey("raw", kekRaw, { name: "AES-GCM" }, false, ["encrypt", "decrypt"]);
+    return { kek: kek, authVerifier: b64(authRaw) };
+  }
+  async function aesEncrypt(key, dataU8) {
+    var iv = crypto.getRandomValues(new Uint8Array(12));
+    var ct = await crypto.subtle.encrypt({ name: "AES-GCM", iv: iv }, key, dataU8);
+    return JSON.stringify({ iv: b64(iv), ct: b64(ct) });
+  }
+  async function aesDecrypt(key, blobStr) {
+    var o = JSON.parse(blobStr);
+    var pt = await crypto.subtle.decrypt({ name: "AES-GCM", iv: unb64(o.iv) }, key, unb64(o.ct));
+    return new Uint8Array(pt);
+  }
+  async function newDek() { return crypto.subtle.generateKey({ name: "AES-GCM", length: 256 }, true, ["encrypt", "decrypt"]); }
+  async function wrapDek(kek, dek) { return aesEncrypt(kek, new Uint8Array(await crypto.subtle.exportKey("raw", dek))); }
+  async function unwrapDek(kek, wrapped) {
+    var raw = await aesDecrypt(kek, wrapped);
+    return crypto.subtle.importKey("raw", raw, { name: "AES-GCM" }, true, ["encrypt", "decrypt"]);
+  }
+  async function encryptVault(dek, items) { return aesEncrypt(dek, enc.encode(JSON.stringify(items))); }
+  async function decryptVault(dek, blob) { if (!blob) return []; return JSON.parse(dec.decode(await aesDecrypt(dek, blob))); }
+  function randSalt() { return b64(crypto.getRandomValues(new Uint8Array(16))); }
+  function uuid() { return (crypto.randomUUID && crypto.randomUUID()) || (Date.now() + "-" + Math.random().toString(16).slice(2)); }
+
+  /* =========================================================================
+   * API
+   * ========================================================================= */
+  async function api(path, method, body) {
+    var headers = {};
+    if (body) headers["Content-Type"] = "application/json";
+    if (S.token) headers["Authorization"] = "Bearer " + S.token;
+    var res;
+    try {
+      res = await fetch(API_BASE + path, { method: method || "GET", headers: headers, body: body ? JSON.stringify(body) : undefined });
+    } catch (e) { var ne = new Error("Can't reach the server. Check your connection and try again."); ne.status = 0; throw ne; }
+    var data = {};
+    try { data = await res.json(); } catch (_) {}
+    if (data && data.token) S.token = data.token;   // sliding session refresh
+    if (!res.ok) { var err = new Error((data && data.error) || ("Error " + res.status)); err.status = res.status; err.data = data; throw err; }
+    return data;
+  }
+
+  /* =========================================================================
+   * Auth flow
+   * ========================================================================= */
+  function setBusy(btn, busy, labelWhenBusy) {
+    if (!btn) return;
+    if (busy) { btn.dataset.label = btn.textContent; btn.disabled = true; btn.textContent = labelWhenBusy || "Please wait…"; }
+    else { btn.disabled = false; if (btn.dataset.label) btn.textContent = btn.dataset.label; }
+  }
+
+  async function onEmailContinue() {
+    var email = $("#email-input").value.trim().toLowerCase();
+    $("#email-err").textContent = "";
+    if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email)) { $("#email-err").textContent = "Enter a valid email address."; return; }
+    var btn = $("#email-continue"); setBusy(btn, true, "Checking…");
+    try {
+      var r = await api("/api/auth/start", "POST", { email: email });
+      S.email = email;
+      if (r.admin) { await startAdmin(); }
+      else if (r.registered) { S.salt = r.salt; S.iters = r.iters || DEFAULT_ITERS; showPassword(); }
+      else if (r.authorized) { S.iters = r.iters || DEFAULT_ITERS; showRegister(); }
+      else { $("#email-err").textContent = "This email isn't set up yet. Contact Linear IT to get access."; }
+    } catch (e) { $("#email-err").textContent = e.message; }
+    finally { setBusy(btn, false); }
+  }
+
+  function showPassword() {
+    S.mode = "login"; $("#pw-email").textContent = S.email; $("#pw-input").value = ""; $("#pw-err").textContent = "";
+    show("password"); setTimeout(function () { $("#pw-input").focus(); }, 30);
+  }
+  async function onPasswordContinue() {
+    var pw = $("#pw-input").value; $("#pw-err").textContent = "";
+    if (!pw) { $("#pw-err").textContent = "Enter your master password."; return; }
+    var btn = $("#pw-continue"); setBusy(btn, true, "Unlocking…");
+    try {
+      var keys = await deriveKeys(pw, unb64(S.salt), S.iters);
+      S.kek = keys.kek; S.authVerifier = keys.authVerifier;
+      await api("/api/auth/login", "POST", { email: S.email, auth_verifier: S.authVerifier }); // phase 1 -> emails a code
+      showCode();
+    } catch (e) { $("#pw-err").textContent = e.message; S.kek = null; }
+    finally { setBusy(btn, false); }
+  }
+
+  function showRegister() {
+    S.mode = "register";
+    $("#reg-email").textContent = S.email; $("#reg-pw").value = ""; $("#reg-pw2").value = "";
+    $("#reg-err").textContent = ""; updateRegMeter();
+    show("register"); setTimeout(function () { $("#reg-pw").focus(); }, 30);
+  }
+  async function onRegisterContinue() {
+    var pw = $("#reg-pw").value, pw2 = $("#reg-pw2").value; $("#reg-err").textContent = "";
+    if (pw.length < 10) { $("#reg-err").textContent = "Use a master password of at least 10 characters."; return; }
+    if (pw !== pw2) { $("#reg-err").textContent = "The two passwords don't match."; return; }
+    var btn = $("#reg-continue"); setBusy(btn, true, "Setting up…");
+    try {
+      // Build all key material locally, then ask for an email code to finish.
+      S.salt = randSalt(); S.iters = DEFAULT_ITERS;
+      var keys = await deriveKeys(pw, unb64(S.salt), S.iters);
+      S.kek = keys.kek; S.authVerifier = keys.authVerifier;
+      S.dek = await newDek();
+      S.wrappedDek = await wrapDek(S.kek, S.dek);
+      S.items = [];
+      S.pendingVaultBlob = await encryptVault(S.dek, S.items);
+      await api("/api/auth/code", "POST", { email: S.email, purpose: "register" });
+      showCode();
+    } catch (e) { $("#reg-err").textContent = e.message; }
+    finally { setBusy(btn, false); }
+  }
+
+  async function startAdmin() {
+    S.mode = "admin";
+    await api("/api/auth/code", "POST", { email: S.email, purpose: "admin" });
+    showCode();
+  }
+
+  function showCode() {
+    $("#code-email").textContent = S.email; $("#code-input").value = ""; $("#code-err").textContent = "";
+    show("code"); setTimeout(function () { $("#code-input").focus(); }, 30);
+  }
+  async function onCodeVerify() {
+    var code = $("#code-input").value.trim(); $("#code-err").textContent = "";
+    if (!/^\d{4,8}$/.test(code)) { $("#code-err").textContent = "Enter the 6-digit code from your email."; return; }
+    var btn = $("#code-verify"); setBusy(btn, true, "Verifying…");
+    try {
+      if (S.mode === "admin") {
+        await api("/api/admin/login", "POST", { email: S.email, code: code });
+        S.isAdmin = true; openAdmin();
+      } else if (S.mode === "register") {
+        var rr = await api("/api/auth/register", "POST", {
+          email: S.email, code: code, salt: S.salt, iters: S.iters,
+          auth_verifier: S.authVerifier, wrapped_dek: S.wrappedDek, vault_blob: S.pendingVaultBlob,
+        });
+        S.vaultVer = rr.vault_ver || 1; S.pendingVaultBlob = null;
+        openVault();
+      } else { // login phase 2
+        var lr = await api("/api/auth/login", "POST", { email: S.email, auth_verifier: S.authVerifier, code: code });
+        S.salt = lr.salt; S.iters = lr.iters; S.wrappedDek = lr.wrapped_dek; S.vaultVer = lr.vault_ver || 0;
+        S.dek = await unwrapDek(S.kek, lr.wrapped_dek);
+        S.items = await decryptVault(S.dek, lr.vault_blob);
+        openVault();
+      }
+    } catch (e) { $("#code-err").textContent = e.message; }
+    finally { setBusy(btn, false); }
+  }
+  async function onCodeResend() {
+    $("#code-err").textContent = "";
+    try {
+      if (S.mode === "login") await api("/api/auth/login", "POST", { email: S.email, auth_verifier: S.authVerifier });
+      else await api("/api/auth/code", "POST", { email: S.email, purpose: S.mode });
+      toast("New code sent", "ok");
+    } catch (e) { $("#code-err").textContent = e.message; }
+  }
+
+  /* ---- Sign out / lock (wipe everything sensitive from memory) ---- */
+  function lock(message) {
+    disarmIdle(); closeModal();
+    S = freshState();
+    show("email");
+    $("#email-input").value = ""; $("#email-err").textContent = "";
+    if (message) toast(message, "");
+  }
+
+  /* =========================================================================
+   * Vault UI
+   * ========================================================================= */
+  function openVault() {
+    S.isAdmin = false; $("#who").textContent = S.email; $("#search").value = ""; S.query = ""; S.folder = "pc";
+    show("vault"); renderFolders(); renderEntries(); armIdle();
+  }
+  function renderFolders() {
+    var wrap = $("#folders"); wrap.textContent = "";
+    FOLDERS.forEach(function (f) {
+      var count = S.items.filter(function (it) { return it.folder === f.id; }).length;
+      var node = h("button", { class: "folder" + (S.folder === f.id ? " active" : ""), onclick: function () { S.folder = f.id; renderFolders(); renderEntries(); } }, [
+        h("span", { class: "ico", html: IC[f.icon] }),
+        h("span", { class: "fname", text: f.name }),
+        h("span", { class: "fcount", text: count + (count === 1 ? " item" : " items") }),
+      ]);
+      wrap.appendChild(node);
+    });
+  }
+  function currentList() {
+    var q = S.query.trim().toLowerCase();
+    return S.items
+      .filter(function (it) { return it.folder === S.folder; })
+      .filter(function (it) {
+        if (!q) return true;
+        return (it.title + " " + it.username + " " + (it.url || "") + " " + (it.notes || "")).toLowerCase().indexOf(q) >= 0;
+      })
+      .sort(function (a, b) { return (a.title || "").localeCompare(b.title || ""); });
+  }
+  function renderEntries() {
+    $("#folder-title").textContent = folderName(S.folder);
+    var box = $("#entries"); box.textContent = "";
+    var list = currentList();
+    if (!list.length) {
+      box.appendChild(h("div", { class: "empty" }, [
+        h("div", { html: IC.key }),
+        h("div", { text: S.query ? "No items match your search." : "No items here yet. Tap + to add one." }),
+      ]));
+      return;
+    }
+    list.forEach(function (it) { box.appendChild(entryCard(it)); });
+  }
+  function entryCard(it) {
+    var initial = (it.title || "?").trim().charAt(0).toUpperCase() || "?";
+    var card = h("div", { class: "entry" });
+    var pwShown = false;
+
+    var pwVal = h("span", { class: "v mono", text: "••••••••••" });
+    var revealBtn = h("button", { class: "iconbtn", title: "Show/hide" }, [icon("eye")]);
+    revealBtn.addEventListener("click", function (e) {
+      e.stopPropagation(); pwShown = !pwShown;
+      pwVal.textContent = pwShown ? (it.password || "") : "••••••••••";
+      revealBtn.textContent = ""; revealBtn.appendChild(icon(pwShown ? "eyeoff" : "eye"));
+    });
+
+    var row1 = h("div", { class: "row1" }, [
+      h("span", { class: "avatar", text: initial }),
+      h("div", {}, [h("div", { class: "etitle", text: it.title || "(untitled)" }), h("div", { class: "euser", text: it.username || "" })]),
+      h("div", { class: "acts" }, [
+        actBtn("copy", "Copy password", function (e) { e.stopPropagation(); copy(it.password, "Password"); }),
+        actBtn("edit", "Edit", function (e) { e.stopPropagation(); openEntryModal(it); }),
+      ]),
+    ]);
+    row1.addEventListener("click", function () { card.classList.toggle("open"); });
+
+    var detail = h("div", { class: "detail" }, [
+      kv("User", it.username || "—", it.username ? function () { copy(it.username, "Username"); } : null),
+      h("div", { class: "kv" }, [
+        h("span", { class: "k", text: "Pass" }), pwVal,
+        h("div", { class: "miniacts" }, [revealBtn, actBtn("copy", "Copy", function (e) { e.stopPropagation(); copy(it.password, "Password"); })]),
+      ]),
+      it.url ? h("div", { class: "kv" }, [
+        h("span", { class: "k", text: "URL" }),
+        h("a", { class: "v", href: safeUrl(it.url), target: "_blank", rel: "noopener noreferrer", text: it.url }),
+        h("div", { class: "miniacts" }, [actBtn("ext", "Open", function (e) { e.stopPropagation(); openUrl(it.url); })]),
+      ]) : null,
+      it.notes ? kv("Notes", it.notes, null) : null,
+      h("div", { style: "display:flex;gap:8px;margin-top:4px" }, [
+        h("button", { class: "btn ghost sm", onclick: function (e) { e.stopPropagation(); openEntryModal(it); } }, [icon("edit"), " Edit"]),
+        h("button", { class: "btn ghost sm", style: "color:var(--danger)", onclick: function (e) { e.stopPropagation(); confirmDelete(it); } }, [icon("trash"), " Delete"]),
+      ]),
+    ]);
+    card.appendChild(row1); card.appendChild(detail);
+    return card;
+  }
+  function actBtn(ic, title, fn) { var b = h("button", { class: "iconbtn", title: title, onclick: fn }, [icon(ic)]); return b; }
+  function kv(k, v, copyFn) {
+    return h("div", { class: "kv" }, [
+      h("span", { class: "k", text: k }),
+      h("span", { class: "v", text: v }),
+      copyFn ? h("div", { class: "miniacts" }, [actBtn("copy", "Copy", function (e) { e.stopPropagation(); copyFn(); })]) : null,
+    ]);
+  }
+
+  /* ---- Add / edit entry ---- */
+  function openEntryModal(existing) {
+    var it = existing || { id: null, folder: S.folder, title: "", username: "", password: "", url: "", notes: "" };
+    var isNew = !existing;
+    var pwInput = h("input", { type: "password", autocomplete: "off", value: it.password || "", placeholder: "Password" });
+    var folderSel = h("select", {}, FOLDERS.map(function (f) { var o = h("option", { value: f.id, text: f.name }); if (f.id === it.folder) o.selected = true; return o; }));
+    var titleInput = h("input", { type: "text", autocomplete: "off", value: it.title || "", placeholder: "e.g. Office 365, Dell laptop, Router" });
+    var userInput = h("input", { type: "text", autocomplete: "off", value: it.username || "", placeholder: "Username / email" });
+    var urlInput = h("input", { type: "text", autocomplete: "off", value: it.url || "", placeholder: "https:// (optional)" });
+    var notesInput = h("textarea", { autocomplete: "off", placeholder: "Notes (optional)" }); notesInput.value = it.notes || "";
+    var err = h("div", { class: "err" });
+
+    var revealBtn = h("button", { class: "iconbtn", type: "button", title: "Show" }, [icon("eye")]);
+    revealBtn.addEventListener("click", function () { var s = pwInput.type === "password"; pwInput.type = s ? "text" : "password"; revealBtn.textContent = ""; revealBtn.appendChild(icon(s ? "eyeoff" : "eye")); });
+    var genBtn = h("button", { class: "iconbtn", type: "button", title: "Generate strong password" }, [icon("gen")]);
+    genBtn.addEventListener("click", function () { pwInput.value = genPassword(18); pwInput.type = "text"; revealBtn.textContent = ""; revealBtn.appendChild(icon("eyeoff")); });
+
+    var modal = h("div", { class: "modal" }, [
+      h("h3", { text: isNew ? "Add item" : "Edit item" }),
+      h("div", { class: "msub", text: "Stored encrypted — only you can read it." }),
+      field("Folder", folderSel),
+      field("Name", titleInput),
+      field("Username", userInput),
+      field("Password", h("div", { class: "pw-wrap" }, [pwInput, h("div", { class: "pw-btns" }, [genBtn, revealBtn])])),
+      field("Website", urlInput),
+      field("Notes", notesInput),
+      err,
+      h("div", { class: "actions" }, [
+        h("button", { class: "btn ghost", onclick: closeModal }, "Cancel"),
+        h("button", { class: "btn", onclick: async function (e) {
+          if (!titleInput.value.trim() && !userInput.value.trim() && !pwInput.value) { err.textContent = "Add at least a name or a password."; return; }
+          var btn = e.currentTarget; setBusy(btn, true, "Saving…");
+          var rec = {
+            id: it.id || uuid(), folder: folderSel.value,
+            title: titleInput.value.trim(), username: userInput.value.trim(),
+            password: pwInput.value, url: urlInput.value.trim(), notes: notesInput.value,
+            updated: Date.now(),
+          };
+          if (isNew) S.items.push(rec);
+          else S.items = S.items.map(function (x) { return x.id === rec.id ? rec : x; });
+          try { await persist(); closeModal(); S.folder = rec.folder; renderFolders(); renderEntries(); toast("Saved", "ok"); }
+          catch (er) { err.textContent = er.message; setBusy(btn, false); }
+        } }, isNew ? "Add item" : "Save"),
+      ]),
+    ]);
+    openModal(modal);
+    setTimeout(function () { titleInput.focus(); }, 30);
+  }
+  function field(label, control) { return h("label", { class: "field" }, [h("span", { class: "lbl", text: label }), control]); }
+
+  function confirmDelete(it) {
+    openModal(h("div", { class: "modal" }, [
+      h("h3", { text: "Delete this item?" }),
+      h("div", { class: "msub", text: (it.title || "This item") + " will be permanently removed from your vault." }),
+      h("div", { class: "actions" }, [
+        h("button", { class: "btn ghost", onclick: closeModal }, "Cancel"),
+        h("button", { class: "btn danger", onclick: async function (e) {
+          setBusy(e.currentTarget, true, "Deleting…");
+          S.items = S.items.filter(function (x) { return x.id !== it.id; });
+          try { await persist(); closeModal(); renderFolders(); renderEntries(); toast("Deleted", "ok"); }
+          catch (er) { toast(er.message, "bad"); closeModal(); }
+        } }, "Delete"),
+      ]),
+    ]));
+  }
+
+  /* ---- Persist (encrypt + upload, with conflict guard) ---- */
+  async function persist() {
+    var blob = await encryptVault(S.dek, S.items);
+    try {
+      var r = await api("/api/vault", "PUT", { vault_blob: blob, base_ver: S.vaultVer });
+      S.vaultVer = r.vault_ver;
+    } catch (e) {
+      if (e.status === 409) {
+        // Vault changed on another device since we loaded it — reload to be safe.
+        var g = await api("/api/vault", "GET");
+        S.vaultVer = g.vault_ver; S.items = await decryptVault(S.dek, g.vault_blob);
+        renderFolders(); renderEntries();
+        throw new Error("Your vault was updated on another device, so it was reloaded. Please redo your last change.");
+      }
+      throw e;
+    }
+  }
+
+  /* =========================================================================
+   * Import / Export (CSV — opens in Excel)
+   * ========================================================================= */
+  function csvCell(v) { v = v == null ? "" : String(v); return /[",\r\n]/.test(v) ? '"' + v.replace(/"/g, '""') + '"' : v; }
+  function toCSV(items) {
+    var head = ["folder", "title", "username", "password", "url", "notes"];
+    var lines = [head.join(",")];
+    items.forEach(function (it) {
+      lines.push([folderName(it.folder), it.title, it.username, it.password, it.url, it.notes].map(csvCell).join(","));
+    });
+    return "﻿" + lines.join("\r\n"); // BOM so Excel reads UTF-8 correctly
+  }
+  function exportCSV() {
+    if (!S.items.length) { toast("Nothing to export yet", "bad"); return; }
+    var csv = toCSV(S.items);
+    var blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
+    var url = URL.createObjectURL(blob);
+    var a = h("a", { href: url, download: "linear-vault-" + new Date().toISOString().slice(0, 10) + ".csv" });
+    document.body.appendChild(a); a.click(); document.body.removeChild(a);
+    setTimeout(function () { URL.revokeObjectURL(url); }, 4000);
+    toast(S.items.length + " items exported", "ok");
+  }
+  function parseCSV(text) {
+    text = text.replace(/^﻿/, "");
+    var rows = [], row = [], field = "", i = 0, inQ = false;
+    while (i < text.length) {
+      var c = text[i];
+      if (inQ) {
+        if (c === '"') { if (text[i + 1] === '"') { field += '"'; i += 2; continue; } inQ = false; i++; continue; }
+        field += c; i++; continue;
+      }
+      if (c === '"') { inQ = true; i++; continue; }
+      if (c === ",") { row.push(field); field = ""; i++; continue; }
+      if (c === "\r") { i++; continue; }
+      if (c === "\n") { row.push(field); rows.push(row); row = []; field = ""; i++; continue; }
+      field += c; i++;
+    }
+    if (field.length || row.length) { row.push(field); rows.push(row); }
+    return rows;
+  }
+  function mapFolder(f, url) {
+    f = (f || "").toLowerCase();
+    if (/\bpc\b|device|computer|desktop|laptop|server|workstation/.test(f)) return "pc";
+    if (/online|website|web|account/.test(f)) return "online";
+    if (f === "passwords" || f === "password") return "passwords";
+    if (url && /https?:|www\.|\.[a-z]{2,}/i.test(url)) return "online";
+    return "passwords";
+  }
+  function importRows(rows) {
+    if (!rows.length) return [];
+    var header = rows[0].map(function (x) { return String(x || "").trim().toLowerCase(); });
+    function idx(names) { for (var n = 0; n < names.length; n++) { var k = header.indexOf(names[n]); if (k >= 0) return k; } return -1; }
+    var iF = idx(["folder", "category", "group", "type"]);
+    var iT = idx(["title", "name", "account", "item", "service", "login_name"]);
+    var iU = idx(["username", "user", "login", "login_username", "email", "user name", "e-mail"]);
+    var iP = idx(["password", "pass", "pwd", "login_password"]);
+    var iL = idx(["url", "website", "web site", "site", "login_uri", "uri", "link"]);
+    var iN = idx(["notes", "note", "comment", "comments", "extra"]);
+    var hasHeader = iT >= 0 || iP >= 0 || iU >= 0;
+    var out = [];
+    for (var r = hasHeader ? 1 : 0; r < rows.length; r++) {
+      var row = rows[r]; if (!row || row.every(function (c) { return !String(c || "").trim(); })) continue;
+      var get = function (k) { return k >= 0 && row[k] != null ? String(row[k]) : ""; };
+      var url = get(iL);
+      out.push({
+        id: uuid(), folder: mapFolder(get(iF), url),
+        title: (get(iT) || get(iU) || "(untitled)").trim(),
+        username: get(iU).trim(), password: get(iP), url: url.trim(), notes: get(iN), updated: Date.now(),
+      });
+    }
+    return out;
+  }
+  function onImportFile(ev) {
+    var file = ev.target.files && ev.target.files[0]; ev.target.value = "";
+    if (!file) return;
+    var reader = new FileReader();
+    reader.onload = function () {
+      var incoming;
+      try { incoming = importRows(parseCSV(String(reader.result))); }
+      catch (e) { toast("Couldn't read that file", "bad"); return; }
+      if (!incoming.length) { toast("No rows found in that file", "bad"); return; }
+      openModal(h("div", { class: "modal" }, [
+        h("h3", { text: "Import " + incoming.length + " item" + (incoming.length === 1 ? "" : "s") + "?" }),
+        h("div", { class: "msub", text: "They'll be added to your vault, sorted into PC / Online Accounts / Passwords automatically. Existing items are kept." }),
+        h("div", { class: "actions" }, [
+          h("button", { class: "btn ghost", onclick: closeModal }, "Cancel"),
+          h("button", { class: "btn", onclick: async function (e) {
+            setBusy(e.currentTarget, true, "Importing…");
+            S.items = S.items.concat(incoming);
+            try { await persist(); closeModal(); renderFolders(); renderEntries(); toast("Imported " + incoming.length + " items", "ok"); }
+            catch (er) { toast(er.message, "bad"); closeModal(); }
+          } }, "Import"),
+        ]),
+      ]));
+    };
+    reader.onerror = function () { toast("Couldn't read that file", "bad"); };
+    reader.readAsText(file);
+  }
+
+  /* =========================================================================
+   * Settings — change master password
+   * ========================================================================= */
+  function openSettings() {
+    var cur = h("input", { type: "password", autocomplete: "off", placeholder: "Current master password" });
+    var np = h("input", { type: "password", autocomplete: "new-password", placeholder: "New master password" });
+    var np2 = h("input", { type: "password", autocomplete: "new-password", placeholder: "Confirm new password" });
+    var meter = h("i"); var meterWrap = h("div", { class: "meter" }, [meter]);
+    np.addEventListener("input", function () { setMeter(meter, strength(np.value)); });
+    var err = h("div", { class: "err" });
+    openModal(h("div", { class: "modal" }, [
+      h("h3", { text: "Change master password" }),
+      h("div", { class: "msub", text: "Your saved items are re-secured with the new password. It never leaves this device." }),
+      field("Current password", cur),
+      field("New password", np), meterWrap,
+      field("Confirm new password", np2),
+      err,
+      h("div", { class: "actions" }, [
+        h("button", { class: "btn ghost", onclick: closeModal }, "Cancel"),
+        h("button", { class: "btn", onclick: async function (e) {
+          err.textContent = "";
+          if (np.value.length < 10) { err.textContent = "New password must be at least 10 characters."; return; }
+          if (np.value !== np2.value) { err.textContent = "The new passwords don't match."; return; }
+          var btn = e.currentTarget; setBusy(btn, true, "Updating…");
+          try {
+            var check = await deriveKeys(cur.value, unb64(S.salt), S.iters);
+            if (check.authVerifier !== S.authVerifier) { err.textContent = "Current password is incorrect."; setBusy(btn, false); return; }
+            var newSalt = randSalt(), iters = DEFAULT_ITERS;
+            var keys = await deriveKeys(np.value, unb64(newSalt), iters);
+            var wrapped = await wrapDek(keys.kek, S.dek);
+            await api("/api/account/rekey", "POST", { salt: newSalt, iters: iters, auth_verifier: keys.authVerifier, wrapped_dek: wrapped });
+            S.salt = newSalt; S.iters = iters; S.kek = keys.kek; S.authVerifier = keys.authVerifier; S.wrappedDek = wrapped;
+            closeModal(); toast("Master password changed", "ok");
+          } catch (er) { err.textContent = er.message; setBusy(btn, false); }
+        } }, "Change password"),
+      ]),
+    ]));
+    setTimeout(function () { cur.focus(); }, 30);
+  }
+
+  /* =========================================================================
+   * Admin panel
+   * ========================================================================= */
+  function openAdmin() {
+    disarmIdle(); $("#admin-who").textContent = S.email; show("admin"); armIdle(); loadClients();
+  }
+  async function loadClients() {
+    var tb = $("#admin-rows"); tb.textContent = ""; $("#admin-err").textContent = "";
+    try {
+      var r = await api("/api/admin/clients", "GET");
+      if (!r.clients.length) { tb.appendChild(h("tr", {}, [h("td", { colspan: "3", text: "No clients yet. Approve an email above to get started." })])); return; }
+      r.clients.forEach(function (c) {
+        tb.appendChild(h("tr", {}, [
+          h("td", { text: c.email }),
+          h("td", {}, [h("span", { class: "badge " + (c.registered ? "on" : "off"), text: c.registered ? "Active" : "Approved" })]),
+          h("td", { style: "text-align:right;white-space:nowrap" }, [
+            c.registered ? h("button", { class: "btn ghost sm", title: "Wipe their vault so they can set a new master password", onclick: function () { adminReset(c.email); } }, "Reset") : null,
+            h("button", { class: "btn ghost sm", style: "color:var(--danger);margin-left:6px", onclick: function () { adminRevoke(c.email); } }, "Revoke"),
+          ]),
+        ]));
+      });
+    } catch (e) { $("#admin-err").textContent = e.message; }
+  }
+  async function adminAdd() {
+    var email = $("#admin-new-email").value.trim().toLowerCase(); $("#admin-err").textContent = "";
+    if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email)) { $("#admin-err").textContent = "Enter a valid email address."; return; }
+    try { await api("/api/admin/clients", "POST", { email: email }); $("#admin-new-email").value = ""; toast("Approved " + email, "ok"); loadClients(); }
+    catch (e) { $("#admin-err").textContent = e.message; }
+  }
+  function adminReset(email) {
+    openModal(h("div", { class: "modal" }, [
+      h("h3", { text: "Reset this client?" }),
+      h("div", { class: "msub", text: email + " will lose their saved items and set a brand-new master password next time they sign in. You cannot see their current items. This can't be undone." }),
+      h("div", { class: "actions" }, [
+        h("button", { class: "btn ghost", onclick: closeModal }, "Cancel"),
+        h("button", { class: "btn danger", onclick: async function () { try { await api("/api/admin/reset", "POST", { email: email }); closeModal(); toast("Client reset", "ok"); loadClients(); } catch (e) { toast(e.message, "bad"); } } }, "Reset vault"),
+      ]),
+    ]));
+  }
+  function adminRevoke(email) {
+    openModal(h("div", { class: "modal" }, [
+      h("h3", { text: "Revoke access?" }),
+      h("div", { class: "msub", text: email + " will be removed from the allowlist and their vault deleted. This can't be undone." }),
+      h("div", { class: "actions" }, [
+        h("button", { class: "btn ghost", onclick: closeModal }, "Cancel"),
+        h("button", { class: "btn danger", onclick: async function () { try { await api("/api/admin/clients", "DELETE", { email: email }); closeModal(); toast("Access revoked", "ok"); loadClients(); } catch (e) { toast(e.message, "bad"); } } }, "Revoke"),
+      ]),
+    ]));
+  }
+
+  /* =========================================================================
+   * Helpers: clipboard, generator, strength, url, modal, theme
+   * ========================================================================= */
+  async function copy(text, label) {
+    if (!text) { toast("Nothing to copy", "bad"); return; }
+    try { await navigator.clipboard.writeText(text); toast((label || "Value") + " copied", "ok"); }
+    catch (_) {
+      var ta = h("textarea", { style: "position:fixed;opacity:0" }); ta.value = text; document.body.appendChild(ta); ta.focus(); ta.select();
+      try { document.execCommand("copy"); toast((label || "Value") + " copied", "ok"); } catch (e) { toast("Couldn't copy", "bad"); }
+      document.body.removeChild(ta);
+    }
+  }
+  function genPassword(len) {
+    len = len || 18;
+    var U = "ABCDEFGHJKLMNPQRSTUVWXYZ", L = "abcdefghijkmnpqrstuvwxyz", D = "23456789", Sy = "!@#$%^&*()-_=+?";
+    var all = U + L + D + Sy, out = [], pick = function (set) { return set[crypto.getRandomValues(new Uint32Array(1))[0] % set.length]; };
+    out.push(pick(U), pick(L), pick(D), pick(Sy));
+    while (out.length < len) out.push(pick(all));
+    for (var i = out.length - 1; i > 0; i--) { var j = crypto.getRandomValues(new Uint32Array(1))[0] % (i + 1); var t = out[i]; out[i] = out[j]; out[j] = t; }
+    return out.join("");
+  }
+  function strength(pw) {
+    if (!pw) return 0;
+    var sets = 0; if (/[a-z]/.test(pw)) sets++; if (/[A-Z]/.test(pw)) sets++; if (/\d/.test(pw)) sets++; if (/[^A-Za-z0-9]/.test(pw)) sets++;
+    var pool = sets >= 4 ? 90 : sets === 3 ? 62 : sets === 2 ? 52 : 26;
+    var bits = pw.length * (Math.log(pool) / Math.log(2));
+    if (bits < 40) return 1; if (bits < 60) return 2; if (bits < 90) return 3; return 4;
+  }
+  function setMeter(el, score) {
+    var pct = [0, 25, 50, 75, 100][score] || 0;
+    var col = ["", "var(--danger)", "var(--warn)", "#38bdf8", "var(--success)"][score] || "var(--danger)";
+    el.style.width = pct + "%"; el.style.background = col;
+  }
+  function updateRegMeter() {
+    var pw = $("#reg-pw").value, sc = strength(pw);
+    setMeter($("#reg-meter"), sc);
+    var labels = ["Use at least 10 characters. This is the ONLY key to your vault.", "Weak — add length and variety.", "Fair — a bit longer would help.", "Good password.", "Strong password."];
+    $("#reg-strength").textContent = labels[sc];
+  }
+  function safeUrl(u) { u = String(u || ""); if (/^https?:\/\//i.test(u)) return u; if (/^[\w.-]+\.[a-z]{2,}(\/|$)/i.test(u)) return "https://" + u; return "#"; }
+  function openUrl(u) { var s = safeUrl(u); if (s !== "#") window.open(s, "_blank", "noopener,noreferrer"); else toast("No valid web address", "bad"); }
+
+  function openModal(node) { var root = $("#modal-root"); root.textContent = ""; var bg = h("div", { class: "modal-bg", onclick: function (e) { if (e.target === bg) closeModal(); } }, [node]); root.appendChild(bg); }
+  function closeModal() { $("#modal-root").textContent = ""; }
+
+  function applyTheme(t) { document.documentElement.setAttribute("data-theme", t); try { localStorage.setItem("vault-theme", t); } catch (_) {} }
+  function toggleTheme() { applyTheme(document.documentElement.getAttribute("data-theme") === "light" ? "dark" : "light"); }
+
+  /* =========================================================================
+   * Idle auto-logout (10 minutes)
+   * ========================================================================= */
+  var idleTimer = null, warnTimer = null, warnInterval = null;
+  function signedIn() { return !!S.token && (S.isAdmin || !!S.dek); }
+  function disarmIdle() { clearTimeout(idleTimer); clearTimeout(warnTimer); clearInterval(warnInterval); idleTimer = warnTimer = warnInterval = null; }
+  function armIdle() {
+    disarmIdle();
+    if (!signedIn()) return;
+    warnTimer = setTimeout(showIdleWarning, Math.max(0, IDLE_MS - IDLE_WARN_MS));
+    idleTimer = setTimeout(function () { lock("Signed out after 10 minutes of inactivity."); }, IDLE_MS);
+  }
+  function onActivity() {
+    if (!signedIn()) return;
+    // If the warning modal is up, activity dismisses it and re-arms.
+    if ($("#modal-root").dataset.idle === "1") { closeIdleWarning(); }
+    armIdle();
+  }
+  function showIdleWarning() {
+    var left = Math.round(IDLE_WARN_MS / 1000);
+    var count = h("b", { text: String(left) });
+    var root = $("#modal-root"); root.dataset.idle = "1";
+    openModal(h("div", { class: "modal" }, [
+      h("h3", { text: "Still there?" }),
+      h("div", { class: "msub" }, ["For your security you'll be signed out in ", count, " seconds."]),
+      h("div", { class: "actions" }, [
+        h("button", { class: "btn full", onclick: function () { closeIdleWarning(); armIdle(); } }, "Stay signed in"),
+      ]),
+    ]));
+    warnInterval = setInterval(function () { left--; count.textContent = String(Math.max(0, left)); if (left <= 0) clearInterval(warnInterval); }, 1000);
+  }
+  function closeIdleWarning() { clearInterval(warnInterval); warnInterval = null; var root = $("#modal-root"); delete root.dataset.idle; closeModal(); }
+
+  /* =========================================================================
+   * Wire up
+   * ========================================================================= */
+  function onEnter(el, fn) { el.addEventListener("keydown", function (e) { if (e.key === "Enter") { e.preventDefault(); fn(); } }); }
+  function initReveal(btnSel, inputSel) {
+    $(btnSel).addEventListener("click", function () {
+      var inp = $(inputSel), s = inp.type === "password"; inp.type = s ? "text" : "password";
+      $(btnSel).textContent = ""; $(btnSel).appendChild(icon(s ? "eyeoff" : "eye"));
+    });
+  }
+
+  function init() {
+    try { var t = localStorage.getItem("vault-theme"); if (t) document.documentElement.setAttribute("data-theme", t); } catch (_) {}
+
+    $("#email-continue").addEventListener("click", onEmailContinue);
+    onEnter($("#email-input"), onEmailContinue);
+
+    $("#pw-continue").addEventListener("click", onPasswordContinue);
+    onEnter($("#pw-input"), onPasswordContinue);
+    initReveal("#pw-reveal", "#pw-input");
+    $("#pw-back").addEventListener("click", function () { lock(); });
+
+    $("#reg-continue").addEventListener("click", onRegisterContinue);
+    onEnter($("#reg-pw2"), onRegisterContinue);
+    initReveal("#reg-reveal", "#reg-pw");
+    $("#reg-pw").addEventListener("input", updateRegMeter);
+    $("#reg-back").addEventListener("click", function () { lock(); });
+
+    $("#code-verify").addEventListener("click", onCodeVerify);
+    onEnter($("#code-input"), onCodeVerify);
+    $("#code-input").addEventListener("input", function () { this.value = this.value.replace(/\D/g, "").slice(0, 6); });
+    $("#code-resend").addEventListener("click", onCodeResend);
+    $("#code-back").addEventListener("click", function () { lock(); });
+
+    $("#search").addEventListener("input", function () { S.query = this.value; renderEntries(); });
+    $("#btn-add").addEventListener("click", function () { openEntryModal(null); });
+    $("#btn-import").addEventListener("click", function () { $("#import-file").click(); });
+    $("#import-file").addEventListener("change", onImportFile);
+    $("#btn-export").addEventListener("click", exportCSV);
+    $("#btn-settings").addEventListener("click", openSettings);
+    $("#btn-theme").addEventListener("click", toggleTheme);
+    $("#btn-lock").addEventListener("click", function () { lock("Vault locked."); });
+
+    $("#admin-add").addEventListener("click", adminAdd);
+    onEnter($("#admin-new-email"), adminAdd);
+    $("#admin-theme").addEventListener("click", toggleTheme);
+    $("#admin-lock").addEventListener("click", function () { lock("Signed out."); });
+
+    ["mousemove", "mousedown", "keydown", "touchstart", "scroll", "click"].forEach(function (ev) {
+      window.addEventListener(ev, onActivity, { passive: true });
+    });
+    document.addEventListener("visibilitychange", function () { if (document.visibilityState === "visible") onActivity(); });
+    document.addEventListener("keydown", function (e) { if (e.key === "Escape" && $("#modal-root").dataset.idle !== "1") closeModal(); });
+
+    show("email");
+    setTimeout(function () { $("#email-input").focus(); }, 50);
+  }
+
+  if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", init);
+  else init();
+})();

--- a/vault/index.html
+++ b/vault/index.html
@@ -1,0 +1,309 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="UTF-8"/>
+<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover"/>
+<meta name="robots" content="noindex,nofollow"/>
+<title>Linear Vault</title>
+<!--
+  Strict Content-Security-Policy: the page loads NO third-party code, fonts, or
+  images. The only network calls it may make are to the vault API. This keeps a
+  password manager free of supply-chain risk. All cryptography uses the browser's
+  built-in Web Crypto API (crypto.subtle) — see app.js.
+-->
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; form-action 'none'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; font-src 'self'; script-src 'self'; connect-src 'self' https://vault.linearit.co;"/>
+<meta name="referrer" content="no-referrer"/>
+<style>
+*{box-sizing:border-box;margin:0;padding:0}
+:root,[data-theme="dark"]{
+  --bg:#0f1117;--bg2:#1a1d27;--bg3:#222536;
+  --text:#eef0f6;--muted:#7c85a2;--muted2:#4e5571;
+  --accent:#4f7ef8;--accent-h:#3b6cf5;--accent-bg:rgba(79,126,248,.14);
+  --border:#2a2f45;--border2:#353b56;
+  --card:#181c2a;--card2:#1e2235;
+  --success:#4ade80;--success-bg:rgba(74,222,128,.12);
+  --danger:#f87171;--danger-bg:rgba(248,113,113,.12);
+  --warn:#fbbf24;
+  --shadow:0 8px 30px rgba(0,0,0,.45);
+  --input-bg:#0f1117;
+}
+[data-theme="light"]{
+  --bg:#f4f6fb;--bg2:#ffffff;--bg3:#eef0f8;
+  --text:#1a1d2e;--muted:#5a6080;--muted2:#9aa0bc;
+  --accent:#3b6cf5;--accent-h:#2955d8;--accent-bg:rgba(59,108,245,.08);
+  --border:#dde1ee;--border2:#c8cee0;
+  --card:#ffffff;--card2:#f8f9fd;
+  --success:#16a34a;--success-bg:rgba(22,163,74,.08);
+  --danger:#dc2626;--danger-bg:rgba(220,38,38,.08);
+  --warn:#d97706;
+  --shadow:0 8px 30px rgba(0,0,0,.10);
+  --input-bg:#f4f6fb;
+}
+html,body{height:100%}
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;background:var(--bg);color:var(--text);line-height:1.5;-webkit-font-smoothing:antialiased}
+a{color:var(--accent)}
+button{font:inherit;cursor:pointer;border:none;background:none;color:inherit}
+input,select,textarea{font:inherit}
+.hidden{display:none!important}
+
+/* ---- Buttons ---- */
+.btn{display:inline-flex;align-items:center;justify-content:center;gap:8px;padding:11px 18px;border-radius:10px;font-weight:600;font-size:15px;background:var(--accent);color:#fff;transition:background .15s,transform .05s;border:1px solid transparent}
+.btn:hover{background:var(--accent-h)}
+.btn:active{transform:translateY(1px)}
+.btn:disabled{opacity:.55;cursor:not-allowed}
+.btn.full{width:100%}
+.btn.ghost{background:transparent;color:var(--text);border:1px solid var(--border2)}
+.btn.ghost:hover{background:var(--bg3)}
+.btn.sm{padding:7px 12px;font-size:13px;border-radius:8px}
+.btn.danger{background:var(--danger)}
+.btn.danger:hover{filter:brightness(.92)}
+.iconbtn{display:inline-flex;align-items:center;justify-content:center;width:34px;height:34px;border-radius:8px;color:var(--muted);border:1px solid transparent}
+.iconbtn:hover{background:var(--bg3);color:var(--text)}
+.iconbtn svg{width:18px;height:18px}
+
+/* ---- Inputs ---- */
+label.field{display:block;margin:0 0 14px}
+label.field .lbl{display:block;font-size:13px;font-weight:600;color:var(--muted);margin:0 0 6px}
+input[type=text],input[type=email],input[type=password],input[type=url],input[type=search],select,textarea{
+  width:100%;padding:12px 14px;border-radius:10px;border:1px solid var(--border2);background:var(--input-bg);color:var(--text);outline:none;transition:border-color .15s,box-shadow .15s}
+input:focus,select:focus,textarea:focus{border-color:var(--accent);box-shadow:0 0 0 3px var(--accent-bg)}
+textarea{resize:vertical;min-height:70px}
+.hint{font-size:12.5px;color:var(--muted);margin-top:6px}
+.err{color:var(--danger);font-size:13.5px;margin-top:4px;min-height:1.2em}
+.code-input{text-align:center;letter-spacing:10px;font-size:26px;font-weight:700}
+
+/* ---- Auth card ---- */
+.center-wrap{min-height:100%;display:flex;align-items:center;justify-content:center;padding:28px 16px}
+.card{width:100%;max-width:400px;background:var(--card);border:1px solid var(--border);border-radius:18px;padding:30px 28px;box-shadow:var(--shadow)}
+.brand{display:flex;align-items:center;gap:11px;justify-content:center;margin-bottom:6px}
+.brand img{width:34px;height:34px;border-radius:8px;object-fit:contain}
+.brand b{font-size:19px;letter-spacing:.2px}
+.sub{text-align:center;color:var(--muted);font-size:14px;margin:2px 0 22px}
+.lock-ico{display:flex;justify-content:center;margin-bottom:12px}
+.lock-ico svg{width:38px;height:38px;color:var(--accent)}
+.back-link{display:inline-flex;align-items:center;gap:5px;color:var(--muted);font-size:13.5px;margin-top:16px}
+.back-link:hover{color:var(--text)}
+.email-chip{display:inline-block;background:var(--bg3);border:1px solid var(--border);border-radius:8px;padding:3px 9px;font-size:13px;color:var(--muted);margin-bottom:16px;word-break:break-all}
+
+/* ---- Strength meter ---- */
+.meter{height:6px;border-radius:4px;background:var(--bg3);overflow:hidden;margin-top:8px}
+.meter > i{display:block;height:100%;width:0;transition:width .25s,background .25s}
+
+/* ---- App shell ---- */
+#screen-vault,#screen-admin{min-height:100%;display:flex;flex-direction:column}
+.topbar{display:flex;align-items:center;gap:14px;padding:12px 18px;background:var(--bg2);border-bottom:1px solid var(--border);position:sticky;top:0;z-index:20}
+.topbar .brand{margin:0;gap:9px}
+.topbar .brand b{font-size:16px}
+.topbar .spacer{flex:1}
+.searchwrap{position:relative;flex:1;max-width:420px}
+.searchwrap svg{position:absolute;left:11px;top:50%;transform:translateY(-50%);width:16px;height:16px;color:var(--muted);pointer-events:none}
+.searchwrap input{padding-left:34px;border-radius:9px}
+.who{font-size:12.5px;color:var(--muted);max-width:160px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+
+.main{flex:1;width:100%;max-width:900px;margin:0 auto;padding:20px 18px 90px}
+.folders{display:grid;grid-template-columns:repeat(3,1fr);gap:12px;margin-bottom:22px}
+.folder{display:flex;flex-direction:column;gap:6px;align-items:flex-start;padding:16px;border-radius:14px;background:var(--card);border:1px solid var(--border);transition:border-color .15s,transform .05s,background .15s;text-align:left}
+.folder:hover{border-color:var(--border2)}
+.folder.active{border-color:var(--accent);background:var(--accent-bg)}
+.folder .ico{width:38px;height:38px;border-radius:10px;display:flex;align-items:center;justify-content:center;background:var(--bg3)}
+.folder.active .ico{background:var(--accent);color:#fff}
+.folder .ico svg{width:20px;height:20px}
+.folder .fname{font-weight:600;font-size:15px}
+.folder .fcount{font-size:12.5px;color:var(--muted)}
+
+.toolbar{display:flex;align-items:center;gap:8px;margin-bottom:14px;flex-wrap:wrap}
+.toolbar .title{font-weight:700;font-size:17px;margin-right:auto}
+
+.entries{display:flex;flex-direction:column;gap:10px}
+.entry{background:var(--card);border:1px solid var(--border);border-radius:13px;padding:14px 15px;transition:border-color .15s}
+.entry:hover{border-color:var(--border2)}
+.entry .row1{display:flex;align-items:center;gap:12px}
+.entry .avatar{width:38px;height:38px;border-radius:10px;background:var(--bg3);display:flex;align-items:center;justify-content:center;font-weight:700;color:var(--accent);flex-shrink:0}
+.entry .etitle{font-weight:600;font-size:15px;word-break:break-word}
+.entry .euser{font-size:13px;color:var(--muted);word-break:break-all}
+.entry .acts{margin-left:auto;display:flex;gap:2px;flex-shrink:0}
+.entry .detail{margin-top:12px;padding-top:12px;border-top:1px solid var(--border);display:none;flex-direction:column;gap:9px}
+.entry.open .detail{display:flex}
+.kv{display:flex;align-items:center;gap:9px;font-size:14px}
+.kv .k{width:78px;flex-shrink:0;color:var(--muted);font-size:12.5px;font-weight:600;text-transform:uppercase;letter-spacing:.4px}
+.kv .v{word-break:break-all;flex:1;font-variant-numeric:tabular-nums}
+.kv .v.mono{font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+.kv .miniacts{display:flex;gap:2px;margin-left:auto}
+.empty{text-align:center;color:var(--muted);padding:52px 20px}
+.empty svg{width:44px;height:44px;opacity:.4;margin-bottom:10px}
+
+.fab{position:fixed;right:22px;bottom:22px;width:56px;height:56px;border-radius:50%;background:var(--accent);color:#fff;box-shadow:var(--shadow);display:flex;align-items:center;justify-content:center;z-index:25}
+.fab:hover{background:var(--accent-h)}
+.fab svg{width:26px;height:26px}
+
+/* ---- Modal ---- */
+.modal-bg{position:fixed;inset:0;background:rgba(4,6,12,.66);backdrop-filter:blur(3px);display:flex;align-items:flex-start;justify-content:center;padding:34px 16px;z-index:40;overflow-y:auto}
+.modal{width:100%;max-width:460px;background:var(--card);border:1px solid var(--border);border-radius:18px;padding:24px;box-shadow:var(--shadow);margin:auto}
+.modal h3{font-size:18px;margin-bottom:4px}
+.modal .msub{color:var(--muted);font-size:13.5px;margin-bottom:18px}
+.modal .actions{display:flex;gap:10px;margin-top:22px}
+.modal .actions .btn{flex:1}
+.pw-wrap{position:relative}
+.pw-wrap input{padding-right:82px;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+.pw-wrap .pw-btns{position:absolute;right:6px;top:50%;transform:translateY(-50%);display:flex;gap:2px}
+
+/* ---- Admin table ---- */
+.tablewrap{overflow-x:auto;border:1px solid var(--border);border-radius:13px;background:var(--card)}
+table{width:100%;border-collapse:collapse;min-width:520px}
+th,td{text-align:left;padding:12px 14px;font-size:14px;border-bottom:1px solid var(--border)}
+th{font-size:12px;text-transform:uppercase;letter-spacing:.5px;color:var(--muted);font-weight:700}
+tr:last-child td{border-bottom:none}
+.badge{display:inline-block;padding:3px 9px;border-radius:20px;font-size:12px;font-weight:600}
+.badge.on{background:var(--success-bg);color:var(--success)}
+.badge.off{background:var(--bg3);color:var(--muted)}
+
+/* ---- Toast ---- */
+#toast{position:fixed;left:50%;bottom:28px;transform:translateX(-50%) translateY(20px);background:var(--bg2);border:1px solid var(--border2);color:var(--text);padding:11px 18px;border-radius:11px;box-shadow:var(--shadow);font-size:14px;font-weight:500;opacity:0;pointer-events:none;transition:opacity .2s,transform .2s;z-index:60;max-width:90vw}
+#toast.show{opacity:1;transform:translateX(-50%) translateY(0)}
+#toast.ok{border-color:var(--success)}
+#toast.bad{border-color:var(--danger)}
+
+@media(max-width:560px){
+  .folders{gap:8px}
+  .folder{padding:12px}
+  .folder .fname{font-size:13.5px}
+  .who{display:none}
+  .searchwrap{max-width:none}
+}
+</style>
+</head>
+<body>
+
+<!-- =========================== AUTH SCREENS =========================== -->
+
+<!-- 1. Enter email -->
+<section id="screen-email" class="center-wrap">
+  <div class="card">
+    <div class="brand"><img id="brand-logo1" alt="" src="/logo.png"/><b>Linear Vault</b></div>
+    <p class="sub">Your secure password vault</p>
+    <label class="field"><span class="lbl">Email address</span>
+      <input id="email-input" type="email" autocomplete="username" inputmode="email" placeholder="you@example.com" autofocus/>
+    </label>
+    <div class="err" id="email-err"></div>
+    <button class="btn full" id="email-continue">Continue</button>
+    <p class="hint" style="text-align:center;margin-top:16px">Accounts are set up by Linear IT. <br/>Trouble signing in? Call (845)&nbsp;604-1462.</p>
+  </div>
+</section>
+
+<!-- 2. Existing user: master password -->
+<section id="screen-password" class="center-wrap hidden">
+  <div class="card">
+    <div class="lock-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg></div>
+    <p class="sub" style="margin-bottom:8px">Enter your master password</p>
+    <div style="text-align:center"><span class="email-chip" id="pw-email"></span></div>
+    <label class="field"><span class="lbl">Master password</span>
+      <div class="pw-wrap">
+        <input id="pw-input" type="password" autocomplete="current-password" placeholder="Your master password"/>
+        <div class="pw-btns"><button class="iconbtn" id="pw-reveal" type="button" title="Show"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7Z"/><circle cx="12" cy="12" r="3"/></svg></button></div>
+      </div>
+    </label>
+    <div class="err" id="pw-err"></div>
+    <button class="btn full" id="pw-continue">Unlock</button>
+    <a class="back-link" id="pw-back"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 12H5"/><path d="m12 19-7-7 7-7"/></svg> Use a different email</a>
+  </div>
+</section>
+
+<!-- 3. New (approved) user: create master password -->
+<section id="screen-register" class="center-wrap hidden">
+  <div class="card">
+    <div class="brand"><img alt="" src="/logo.png"/><b>Welcome</b></div>
+    <p class="sub" style="margin-bottom:8px">Create your master password</p>
+    <div style="text-align:center"><span class="email-chip" id="reg-email"></span></div>
+    <label class="field"><span class="lbl">Master password</span>
+      <div class="pw-wrap">
+        <input id="reg-pw" type="password" autocomplete="new-password" placeholder="Choose a strong password"/>
+        <div class="pw-btns"><button class="iconbtn" id="reg-reveal" type="button" title="Show"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7Z"/><circle cx="12" cy="12" r="3"/></svg></button></div>
+      </div>
+      <div class="meter"><i id="reg-meter"></i></div>
+      <div class="hint" id="reg-strength">Use at least 10 characters. This is the ONLY key to your vault.</div>
+    </label>
+    <label class="field"><span class="lbl">Confirm master password</span>
+      <input id="reg-pw2" type="password" autocomplete="new-password" placeholder="Type it again"/>
+    </label>
+    <div class="err" id="reg-err"></div>
+    <button class="btn full" id="reg-continue">Create vault</button>
+    <p class="hint" style="margin-top:14px"><b style="color:var(--warn)">Important:</b> if you forget this password, your saved items can't be recovered — Linear IT can only reset your vault to empty.</p>
+    <a class="back-link" id="reg-back"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 12H5"/><path d="m12 19-7-7 7-7"/></svg> Use a different email</a>
+  </div>
+</section>
+
+<!-- 4. MFA code (login / register / admin) -->
+<section id="screen-code" class="center-wrap hidden">
+  <div class="card">
+    <div class="lock-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="m22 7-10 6L2 7"/></svg></div>
+    <p class="sub" style="margin-bottom:8px">Enter the 6-digit code we emailed you</p>
+    <div style="text-align:center"><span class="email-chip" id="code-email"></span></div>
+    <label class="field">
+      <input id="code-input" class="code-input" type="text" inputmode="numeric" autocomplete="one-time-code" maxlength="6" placeholder="000000"/>
+    </label>
+    <div class="err" id="code-err"></div>
+    <button class="btn full" id="code-verify">Verify &amp; open vault</button>
+    <div style="text-align:center;margin-top:14px">
+      <button class="back-link" id="code-resend" type="button">Resend code</button>
+    </div>
+    <a class="back-link" id="code-back"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 12H5"/><path d="m12 19-7-7 7-7"/></svg> Start over</a>
+  </div>
+</section>
+
+<!-- =========================== VAULT =========================== -->
+<section id="screen-vault" class="hidden">
+  <div class="topbar">
+    <div class="brand"><img alt="" src="/logo.png"/><b>Linear Vault</b></div>
+    <div class="searchwrap"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/></svg><input id="search" type="search" placeholder="Search this vault…" autocomplete="off"/></div>
+    <span class="spacer"></span>
+    <span class="who" id="who"></span>
+    <button class="iconbtn" id="btn-theme" title="Theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/></svg></button>
+    <button class="iconbtn" id="btn-settings" title="Settings"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1Z"/></svg></button>
+    <button class="iconbtn" id="btn-lock" title="Lock now"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg></button>
+  </div>
+  <div class="main">
+    <div class="folders" id="folders"></div>
+    <div class="toolbar">
+      <span class="title" id="folder-title">All items</span>
+      <input id="import-file" type="file" accept=".csv,text/csv" class="hidden"/>
+      <button class="btn ghost sm" id="btn-import"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><path d="M12 3v12"/><path d="m7 10 5 5 5-5"/></svg> Import</button>
+      <button class="btn ghost sm" id="btn-export"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><path d="M12 15V3"/><path d="m7 8 5-5 5 5"/></svg> Export</button>
+    </div>
+    <div class="entries" id="entries"></div>
+  </div>
+  <button class="fab" id="btn-add" title="Add item"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14"/><path d="M5 12h14"/></svg></button>
+</section>
+
+<!-- =========================== ADMIN =========================== -->
+<section id="screen-admin" class="hidden">
+  <div class="topbar">
+    <div class="brand"><img alt="" src="/logo.png"/><b>Vault Admin</b></div>
+    <span class="spacer"></span>
+    <span class="who" id="admin-who"></span>
+    <button class="iconbtn" id="admin-theme" title="Theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/></svg></button>
+    <button class="iconbtn" id="admin-lock" title="Sign out"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg></button>
+  </div>
+  <div class="main" style="max-width:820px">
+    <h2 style="font-size:20px;margin-bottom:4px">Client accounts</h2>
+    <p style="color:var(--muted);font-size:14px;margin-bottom:20px">Approve a client's email so they can set up a vault. You can never see their passwords — only reset or revoke access.</p>
+    <div class="toolbar" style="gap:10px">
+      <input id="admin-new-email" type="email" placeholder="client@example.com" style="max-width:320px" autocomplete="off"/>
+      <button class="btn sm" id="admin-add"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14"/><path d="M5 12h14"/></svg> Approve email</button>
+    </div>
+    <div class="err" id="admin-err"></div>
+    <div class="tablewrap" style="margin-top:8px">
+      <table>
+        <thead><tr><th>Email</th><th>Status</th><th style="text-align:right">Actions</th></tr></thead>
+        <tbody id="admin-rows"></tbody>
+      </table>
+    </div>
+  </div>
+</section>
+
+<!-- Modal + toast mount points -->
+<div id="modal-root"></div>
+<div id="toast"></div>
+
+<script src="/vault/app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
A simple, secure password manager for Linear IT clients. Clients sign in with a **master password + an email MFA code**, and see three folders — **PC**, **Online Accounts**, and **Passwords**.

## Security model — zero-knowledge
The master password never leaves the browser. PBKDF2 stretches it into a key-encryption key; a random data key encrypts the vault with AES-256-GCM and is itself wrapped by the KEK. The Cloudflare Worker and its D1 database store **only ciphertext** plus a peppered hash used to authenticate — so no one with access to the server, the database, or Cloudflare can read a client's saved passwords. (Trade-off, per product decision: a forgotten master password can only be **reset to empty** by an admin, never recovered.)

## What's included
**Front end — `/vault/` (GitHub Pages)**
- `index.html` + `app.js`, fully self-contained: no third-party scripts or fonts, strict CSP, all crypto via the browser's Web Crypto API. `noindex`, no README (by request).
- Three folders, add/edit/delete, search, reveal/copy, built-in password generator + strength meter.
- CSV import/export (Excel-compatible: UTF-8 BOM, RFC 4180 quoting; import auto-sorts into the three folders and understands common Chrome/Bitwarden exports).
- Auto-locks and wipes the in-memory key after 10 minutes idle, with a 45-second warning. Nothing sensitive persists across reloads.
- Admin panel (for `ADMIN_EMAILS`) to approve / reset / revoke client emails.

**Back end — Cloudflare Worker `linear-vault` at `vault.linearit.co` (`/vault-worker/`)**
- Isolated worker (own folder + `wrangler.toml`, `custom_domain = true`), matching the `device-worker` pattern.
- Admin-approved allowlist; two-phase login (verify master password, then email a code); MFA codes via Resend from `alert@linearit.co`; HMAC session tokens with sliding expiry; per-account brute-force lockout; D1 with self-provisioning schema; and a reverse proxy so the app is reachable at `vault.linearit.co` too.

## Deploy (after merge)
```
cd vault-worker && npm install
npx wrangler d1 create linear_vault        # paste the id into wrangler.toml
npx wrangler secret put AUTH_SECRET        # long random string
npx wrangler secret put RESEND_API_KEY     # existing Resend key
npx wrangler secret put EMAIL_FROM         # Linear IT <alert@linearit.co>
npx wrangler secret put ADMIN_EMAILS       # admin login address(es)
npx wrangler deploy                        # provisions vault.linearit.co
```
Merging this PR publishes `/vault/` on GitHub Pages; D1 tables create themselves on first request.

## Verification
- 13 Web Crypto round-trip checks: derive → wrap DEK → encrypt/decrypt, wrong-password rejection, master-password change (rekey without re-encrypting), and CSV escaping.
- Full browser end-to-end run: register → save → lock → **re-login and decrypt** → wrong-password rejection → CSV export → admin panel. All green, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112Zk3DRBQn6EjpmQZTTyRX

---
_Generated by [Claude Code](https://claude.ai/code/session_0112Zk3DRBQn6EjpmQZTTyRX)_