### PR TITLE
Brand the vault (logo, cyan accent, backdrop) + revert debug

### DIFF
--- a/vault-worker/src/index.js
+++ b/vault-worker/src/index.js
@@ -159,7 +159,7 @@ async function authCode(request, env) {
   }
 
   const r = await issueCode(env, email, purpose);
-  if (r.error) return json({ error: r.error, detail: r.detail }, r.status);
+  if (r.error) return json({ error: r.error }, r.status);
   const out = { ok: true };
   if (r.dev_code) out.dev_code = r.dev_code;
   return json(out);
@@ -294,7 +294,7 @@ async function authLogin(request, env) {
   // Phase 1: no code yet -> send one to the email (2nd factor).
   if (!hasCode) {
     const r = await issueCode(env, email, "login");
-    if (r.error) return json({ error: r.error, detail: r.detail }, r.status);
+    if (r.error) return json({ error: r.error }, r.status);
     const out = { mfa: true };
     if (r.dev_code) out.dev_code = r.dev_code;
     return json(out);

--- a/vault/index.html
+++ b/vault/index.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover"/>
 <meta name="robots" content="noindex,nofollow"/>
 <title>Linear Vault</title>
+<link rel="icon" href="/favicon.png"/>
 <!--
   Strict Content-Security-Policy: the page loads NO third-party code, fonts, or
   images. The only network calls it may make are to the vault API. This keeps a
@@ -18,7 +19,7 @@
 :root,[data-theme="dark"]{
   --bg:#0f1117;--bg2:#1a1d27;--bg3:#222536;
   --text:#eef0f6;--muted:#7c85a2;--muted2:#4e5571;
-  --accent:#4f7ef8;--accent-h:#3b6cf5;--accent-bg:rgba(79,126,248,.14);
+  --accent:#00b0ec;--accent-h:#009bd2;--accent-bg:rgba(0,176,236,.16);
   --border:#2a2f45;--border2:#353b56;
   --card:#181c2a;--card2:#1e2235;
   --success:#4ade80;--success-bg:rgba(74,222,128,.12);
@@ -30,7 +31,7 @@
 [data-theme="light"]{
   --bg:#f4f6fb;--bg2:#ffffff;--bg3:#eef0f8;
   --text:#1a1d2e;--muted:#5a6080;--muted2:#9aa0bc;
-  --accent:#3b6cf5;--accent-h:#2955d8;--accent-bg:rgba(59,108,245,.08);
+  --accent:#0091c9;--accent-h:#007cae;--accent-bg:rgba(0,145,201,.10);
   --border:#dde1ee;--border2:#c8cee0;
   --card:#ffffff;--card2:#f8f9fd;
   --success:#16a34a;--success-bg:rgba(22,163,74,.08);
@@ -41,6 +42,8 @@
 }
 html,body{height:100%}
 body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;background:var(--bg);color:var(--text);line-height:1.5;-webkit-font-smoothing:antialiased}
+body::before{content:"";position:fixed;inset:0;z-index:-1;pointer-events:none;background-image:url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20width%3D%2790%27%20height%3D%2790%27%20viewBox%3D%270%200%2090%2090%27%3E%3Cg%20fill%3D%27%2300b0ec%27%3E%3Crect%20x%3D%27-2.5%27%20y%3D%27-6.5%27%20width%3D%275%27%20height%3D%2713%27%20rx%3D%272.5%27%20transform%3D%27translate%2845%2C45%29%20rotate%280%29%20translate%280%2C-21%29%20rotate%2822%29%27%2F%3E%3Crect%20x%3D%27-2.5%27%20y%3D%27-6.5%27%20width%3D%275%27%20height%3D%2713%27%20rx%3D%272.5%27%20transform%3D%27translate%2845%2C45%29%20rotate%2845%29%20translate%280%2C-21%29%20rotate%2822%29%27%2F%3E%3Crect%20x%3D%27-2.5%27%20y%3D%27-6.5%27%20width%3D%275%27%20height%3D%2713%27%20rx%3D%272.5%27%20transform%3D%27translate%2845%2C45%29%20rotate%2890%29%20translate%280%2C-21%29%20rotate%2822%29%27%2F%3E%3Crect%20x%3D%27-2.5%27%20y%3D%27-6.5%27%20width%3D%275%27%20height%3D%2713%27%20rx%3D%272.5%27%20transform%3D%27translate%2845%2C45%29%20rotate%28135%29%20translate%280%2C-21%29%20rotate%2822%29%27%2F%3E%3Crect%20x%3D%27-2.5%27%20y%3D%27-6.5%27%20width%3D%275%27%20height%3D%2713%27%20rx%3D%272.5%27%20transform%3D%27translate%2845%2C45%29%20rotate%28180%29%20translate%280%2C-21%29%20rotate%2822%29%27%2F%3E%3Crect%20x%3D%27-2.5%27%20y%3D%27-6.5%27%20width%3D%275%27%20height%3D%2713%27%20rx%3D%272.5%27%20transform%3D%27translate%2845%2C45%29%20rotate%28225%29%20translate%280%2C-21%29%20rotate%2822%29%27%2F%3E%3Crect%20x%3D%27-2.5%27%20y%3D%27-6.5%27%20width%3D%275%27%20height%3D%2713%27%20rx%3D%272.5%27%20transform%3D%27translate%2845%2C45%29%20rotate%28270%29%20translate%280%2C-21%29%20rotate%2822%29%27%2F%3E%3Crect%20x%3D%27-2.5%27%20y%3D%27-6.5%27%20width%3D%275%27%20height%3D%2713%27%20rx%3D%272.5%27%20transform%3D%27translate%2845%2C45%29%20rotate%28315%29%20translate%280%2C-21%29%20rotate%2822%29%27%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E");background-size:90px 90px;opacity:.07}
+[data-theme="light"] body::before{opacity:.10}
 a{color:var(--accent)}
 button{font:inherit;cursor:pointer;border:none;background:none;color:inherit}
 input,select,textarea{font:inherit}
@@ -76,8 +79,11 @@ textarea{resize:vertical;min-height:70px}
 .center-wrap{min-height:100%;display:flex;align-items:center;justify-content:center;padding:28px 16px}
 .card{width:100%;max-width:400px;background:var(--card);border:1px solid var(--border);border-radius:18px;padding:30px 28px;box-shadow:var(--shadow)}
 .brand{display:flex;align-items:center;gap:11px;justify-content:center;margin-bottom:6px}
-.brand img{width:34px;height:34px;border-radius:8px;object-fit:contain}
+.brand img{height:44px;width:auto;max-width:230px;object-fit:contain}
+.topbar .brand img{height:26px;max-width:150px}
+[data-theme="light"] .brand img{filter:invert(1)}
 .brand b{font-size:19px;letter-spacing:.2px}
+.brandtag{font-size:14px;font-weight:700;color:var(--muted);padding-left:11px;margin-left:3px;border-left:1px solid var(--border2)}
 .sub{text-align:center;color:var(--muted);font-size:14px;margin:2px 0 22px}
 .lock-ico{display:flex;justify-content:center;margin-bottom:12px}
 .lock-ico svg{width:38px;height:38px;color:var(--accent)}
@@ -179,7 +185,7 @@ tr:last-child td{border-bottom:none}
 <!-- 1. Enter email -->
 <section id="screen-email" class="center-wrap">
   <div class="card">
-    <div class="brand"><img id="brand-logo1" alt="" src="/logo.png"/><b>Linear Vault</b></div>
+    <div class="brand"><img alt="Linear IT" src="/logo.png"/></div>
     <p class="sub">Your secure password vault</p>
     <label class="field"><span class="lbl">Email address</span>
       <input id="email-input" type="email" autocomplete="username" inputmode="email" placeholder="you@example.com" autofocus/>
@@ -211,7 +217,7 @@ tr:last-child td{border-bottom:none}
 <!-- 3. New (approved) user: create master password -->
 <section id="screen-register" class="center-wrap hidden">
   <div class="card">
-    <div class="brand"><img alt="" src="/logo.png"/><b>Welcome</b></div>
+    <div class="brand"><img alt="Linear IT" src="/logo.png"/></div>
     <p class="sub" style="margin-bottom:8px">Create your master password</p>
     <div style="text-align:center"><span class="email-chip" id="reg-email"></span></div>
     <label class="field"><span class="lbl">Master password</span>
@@ -253,7 +259,7 @@ tr:last-child td{border-bottom:none}
 <!-- =========================== VAULT =========================== -->
 <section id="screen-vault" class="hidden">
   <div class="topbar">
-    <div class="brand"><img alt="" src="/logo.png"/><b>Linear Vault</b></div>
+    <div class="brand"><img alt="Linear IT" src="/logo.png"/><span class="brandtag">Vault</span></div>
     <div class="searchwrap"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/></svg><input id="search" type="search" placeholder="Search this vault…" autocomplete="off"/></div>
     <span class="spacer"></span>
     <span class="who" id="who"></span>
@@ -277,7 +283,7 @@ tr:last-child td{border-bottom:none}
 <!-- =========================== ADMIN =========================== -->
 <section id="screen-admin" class="hidden">
   <div class="topbar">
-    <div class="brand"><img alt="" src="/logo.png"/><b>Vault Admin</b></div>
+    <div class="brand"><img alt="Linear IT" src="/logo.png"/><span class="brandtag">Admin</span></div>
     <span class="spacer"></span>
     <span class="who" id="admin-who"></span>
     <button class="iconbtn" id="admin-theme" title="Theme"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/></svg></button>


### PR DESCRIPTION
Applies Linear IT branding to the vault and reverts the temporary email diagnostic now that Resend delivery works.

- **Logo:** show the real white "Linear IT" wordmark at a proper size on the login/register cards and top bars (auto-inverted on the light theme), instead of the wide logo crushed into a 34px square.
- **Accent color:** generic blue → the Linear cyan/electric-blue brand color, in both themes.
- **Background:** a subtle tiled ring-mark pattern recreated in CSS from the brand mark — faint so the vault stays readable, adapts to dark/light.
- **Favicon:** browser-tab icon set to the brand mark.
- **Revert:** removed the temporary Resend error `detail` from client responses (server-side `console.error` logging kept).

Verified: full browser smoke test (register → save → lock → re-login decrypt → wrong-password → admin) passes with zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112Zk3DRBQn6EjpmQZTTyRX

---
_Generated by [Claude Code](https://claude.ai/code/session_0112Zk3DRBQn6EjpmQZTTyRX)_