### PR TITLE
Make Linear Time installable from the time.linearit.co root

### DIFF
--- a/time/app.js
+++ b/time/app.js
@@ -814,10 +814,14 @@
   async function boot() {
     bind();
     // Register the service worker (offline shell + reminder notifications).
+    // On time.linearit.co the Worker sends Service-Worker-Allowed:/ so we can take
+    // the whole origin as scope — that makes the site installable from the root
+    // URL (not just /time/). Elsewhere (GitHub Pages) fall back to /time/.
     if ("serviceWorker" in navigator) {
-      try { swReg = await navigator.serviceWorker.register("/time/sw.js", { scope: "/time/" }); } catch (_) {}
-      // Keep the freshest active registration for showNotification().
-      try { navigator.serviceWorker.getRegistration("/time/").then(function (r) { if (r) swReg = r; }); } catch (_) {}
+      var swScope = location.hostname === "time.linearit.co" ? "/" : "/time/";
+      try { swReg = await navigator.serviceWorker.register("/time/sw.js", { scope: swScope }); }
+      catch (_) { try { swReg = await navigator.serviceWorker.register("/time/sw.js", { scope: "/time/" }); } catch (_2) {} }
+      try { navigator.serviceWorker.getRegistration(swScope).then(function (r) { if (r) swReg = r; }); } catch (_) {}
     }
     if (getToken() && getProfile()) routeAfterLogin();
     else routeToAuth();

--- a/time/manifest.webmanifest
+++ b/time/manifest.webmanifest
@@ -4,7 +4,7 @@
   "description": "Track your day, one task at a time — from Linear IT.",
   "id": "/time/",
   "start_url": "/time/",
-  "scope": "/time/",
+  "scope": "/",
   "display": "standalone",
   "background_color": "#0f1117",
   "theme_color": "#0f1117",


### PR DESCRIPTION
Fixes the "can't install as an app" issue: the manifest scope and service-worker scope were both `/time/`, so Edge/Chrome would not offer **Install as an app** when the site was viewed at the root URL `time.linearit.co/` (outside that scope).

## Change
- `time/manifest.webmanifest`: widen `scope` from `/time/` to `/` (keep `start_url` = `/time/` so the installed app always opens the tracker).
- `time/app.js`: register the service worker at scope `/` on the `time.linearit.co` origin (the Worker already returns `Service-Worker-Allowed: /` for `sw.js`); fall back to `/time/` on GitHub Pages where the wider scope isn't permitted.

Result: the app is installable directly from `https://time.linearit.co`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKj7B6z8xX5vBn9TqUotTy)_