### PR TITLE
Request persistent storage so sign-in survives restarts

### DIFF
--- a/time/app.js
+++ b/time/app.js
@@ -813,6 +813,9 @@
 
   async function boot() {
     bind();
+    // Ask the browser to keep our saved sign-in even under storage pressure, so the
+    // session survives restarts (installed PWAs are usually granted this silently).
+    try { if (navigator.storage && navigator.storage.persist) navigator.storage.persist(); } catch (_) {}
     // Register the service worker (offline shell + reminder notifications).
     // On time.linearit.co the Worker sends Service-Worker-Allowed:/ so we can take
     // the whole origin as scope — that makes the site installable from the root


### PR DESCRIPTION
Improves "stay signed in": calls `navigator.storage.persist()` on boot so the browser keeps the saved session token under storage pressure (installed PWAs are usually granted this silently). Makes the persistent session more robust against automatic storage eviction.

Note: this does not override a browser "clear cookies/site data on close" setting — that's a browser/profile configuration, handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKj7B6z8xX5vBn9TqUotTy)_