### PR TITLE
Per-company settings: nudge interval, custom tiles, optional background color

### DIFF
--- a/time-worker/src/index.js
+++ b/time-worker/src/index.js
@@ -34,6 +34,7 @@
  *   GET  /api/admin/report        (admin)  a day's rows for a company (+worker)
  *   GET  /api/admin/workers       (admin)  people in a company
  *   POST /api/admin/worker/rename (admin)  rename a person (scoped to company)
+ *   GET/POST /api/admin/settings  (admin)  per-company nudge interval, tiles, color
  *   GET  /api/admin/companies     (super)  list companies + join codes
  *   POST /api/admin/companies     (super)  create a company (mints a join code)
  *   POST /api/admin/company/code  (super)  regenerate a company's join code
@@ -70,10 +71,16 @@ const TOKEN_TTL_MS = 400 * 24 * 60 * 60 * 1000; // ~13 months, sliding
 const CODE_TTL_MS = 10 * 60 * 1000;       // one-time code lifetime
 const CODE_RESEND_MS = 45 * 1000;         // min gap between code emails to one address
 const MAX_CODE_ATTEMPTS = 5;              // wrong codes before a code is burned
-const PRESETS = ["breakfast", "exercise", "break"]; // the once-a-day quick picks
-const CHECKIN_MS = 30 * 60 * 1000;        // "still on this?" interval
 const WRAP_HOUR = 17;                     // 5pm: start asking to wrap up the day
-const PUSH_THROTTLE_MS = 25 * 60 * 1000;  // don't re-push a worker more often than this
+const DEFAULT_CHECKIN_MIN = 30;           // default "still on this?" interval (minutes)
+// The three once-a-day quick picks. Companies may relabel/re-emoji them, but the
+// three internal keys stay fixed so the "once a day" rule keeps working per slot.
+const DEFAULT_PRESETS = [
+  { key: "breakfast", label: "Breakfast", emoji: "🍳", sub: "Grab a bite" },
+  { key: "exercise", label: "Exercise", emoji: "🏃", sub: "Move a little" },
+  { key: "break", label: "Break", emoji: "☕", sub: "Recharge" },
+];
+const PRESETS = DEFAULT_PRESETS.map((p) => p.key);
 
 export default {
   async fetch(request, env, ctx) {
@@ -132,6 +139,8 @@ async function handleApi(request, env, url, p, method) {
   if (p === "/api/admin/report" && method === "GET") return adminReport(request, env, url);
   if (p === "/api/admin/workers" && method === "GET") return adminWorkers(request, env, url);
   if (p === "/api/admin/worker/rename" && method === "POST") return renameWorker(request, env);
+  if (p === "/api/admin/settings" && method === "GET") return getSettings(request, env, url);
+  if (p === "/api/admin/settings" && method === "POST") return saveSettings(request, env);
 
   // --- super-admin only ---
   if (p === "/api/admin/companies" && method === "GET") return listCompanies(request, env);
@@ -313,6 +322,7 @@ async function dayGet(request, env, url) {
 
   const ended = await env.DB.prepare("SELECT 1 FROM day_end WHERE email=? AND day=?").bind(claims.email, day).first();
   const presetsUsed = rows.filter((r) => r.preset).map((r) => r.preset);
+  const settings = await getCompanySettings(env, claims.company_id);
   return json({
     token: await reissue(env, claims),
     profile: { email: claims.email, name: claims.name || "", company_id: claims.company_id, role: "worker" },
@@ -321,6 +331,9 @@ async function dayGet(request, env, url) {
     running: running ? cleanEntry(running) : null,
     presetsUsed: [...new Set(presetsUsed)],
     presets: PRESETS,
+    presetsMeta: settings.presets,   // [{key,label,emoji,sub}] — company-customized tiles
+    checkinMin: settings.checkinMin, // company nudge interval (minutes)
+    bgColor: settings.bgColor,       // custom background or null
     dayEnded: !!ended,
     wrapHour: WRAP_HOUR,
     serverNow: Date.now(),
@@ -352,11 +365,13 @@ async function taskStart(request, env) {
   // Starting work reopens the day if it had been ended earlier.
   await env.DB.prepare("DELETE FROM day_end WHERE email=? AND day=?").bind(claims.email, day).run();
 
+  const settings = await getCompanySettings(env, claims.company_id);
+  const checkinAt = now + settings.checkinMin * 60000;
   const res = await env.DB.prepare(
     "INSERT INTO entries (email, company_id, day, task, preset, started_at, ended_at, checkin_at, created_at) VALUES (?,?,?,?,?,?,NULL,?,?)"
-  ).bind(claims.email, claims.company_id, day, task, preset, now, now + CHECKIN_MS, now).run();
+  ).bind(claims.email, claims.company_id, day, task, preset, now, checkinAt, now).run();
 
-  return json({ token: await reissue(env, claims), id: res.meta && res.meta.last_row_id, startedAt: now, checkinAt: now + CHECKIN_MS });
+  return json({ token: await reissue(env, claims), id: res.meta && res.meta.last_row_id, startedAt: now, checkinAt: checkinAt });
 }
 
 async function taskEnd(request, env) {
@@ -367,10 +382,11 @@ async function taskEnd(request, env) {
   return json({ token: await reissue(env, claims), endedAt: now, ended: (res.meta && res.meta.changes) || 0 });
 }
 
-// "Yes, keep going" — push the next check-in out another interval.
+// "Yes, keep going" — push the next check-in out another (company) interval.
 async function taskCheckin(request, env) {
   const claims = await requireUser(request, env);
-  const next = Date.now() + CHECKIN_MS;
+  const settings = await getCompanySettings(env, claims.company_id);
+  const next = Date.now() + settings.checkinMin * 60000;
   const res = await env.DB.prepare("UPDATE entries SET checkin_at=? WHERE email=? AND ended_at IS NULL")
     .bind(next, claims.email).run();
   return json({ token: await reissue(env, claims), checkinAt: next, updated: (res.meta && res.meta.changes) || 0 });
@@ -456,11 +472,19 @@ async function computePending(env, email, now, tzOff) {
 async function runReminders(env) {
   if (!env.VAPID_PUBLIC || !env.VAPID_PRIVATE_JWK) return; // push not configured yet
   await ensureSchema(env);
-  const subs = (await env.DB.prepare("SELECT email, endpoint, tz_offset, last_push_at FROM push_subs").all()).results || [];
+  const subs = (await env.DB.prepare(
+    "SELECT p.email, p.endpoint, p.tz_offset, p.last_push_at, w.company_id FROM push_subs p " +
+    "LEFT JOIN workers w ON w.email=p.email"
+  ).all()).results || [];
   const now = Date.now();
+  const minCache = {};
   for (const s of subs) {
     try {
-      if (now - Number(s.last_push_at || 0) < PUSH_THROTTLE_MS) continue;
+      // Re-nudge no more often than the company's own interval (floored to the
+      // 5-min cron granularity), so a shorter interval nags sooner, a longer one later.
+      if (!(s.company_id in minCache)) minCache[s.company_id] = (await getCompanySettings(env, s.company_id)).checkinMin;
+      const throttle = Math.max(4, minCache[s.company_id]) * 60000;
+      if (now - Number(s.last_push_at || 0) < throttle) continue;
       const pend = await computePending(env, s.email, now, Number(s.tz_offset) || 0);
       if (!pend.show) continue;
       const status = await sendPush(env, s.endpoint);
@@ -604,6 +628,52 @@ async function renameWorker(request, env) {
   }
   await env.DB.prepare("UPDATE workers SET name=? WHERE email=?").bind(name, email).run();
   return json({ token: await reissue(env, claims), ok: true });
+}
+
+/* ============================================================
+ * Per-company settings — nudge interval, the 3 tiles, background color
+ * ============================================================ */
+async function getSettings(request, env, url) {
+  const claims = await requireAdmin(request, env);
+  const companyId = scopeCompany(claims, url.searchParams.get("company_id"));
+  if (!companyId) return json({ error: "Pick a company." }, 400);
+  return json({ token: await reissue(env, claims), settings: await getCompanySettings(env, companyId) });
+}
+
+async function saveSettings(request, env) {
+  const claims = await requireAdmin(request, env);
+  const body = await readBody(request);
+  const companyId = scopeCompany(claims, body.company_id);
+  if (!companyId) return json({ error: "Pick a company." }, 400);
+  const exists = await env.DB.prepare("SELECT 1 FROM companies WHERE id=?").bind(companyId).first();
+  if (!exists) return json({ error: "Company not found." }, 404);
+  const norm = normalizeSettings(JSON.stringify({ checkinMin: body.checkinMin, presets: body.presets, bgColor: body.bgColor }));
+  await env.DB.prepare("UPDATE companies SET settings=? WHERE id=?").bind(JSON.stringify(norm), companyId).run();
+  return json({ token: await reissue(env, claims), settings: norm });
+}
+
+// Effective settings for a company (defaults filled in), always safe to render.
+async function getCompanySettings(env, companyId) {
+  const row = companyId ? await env.DB.prepare("SELECT settings FROM companies WHERE id=?").bind(companyId).first() : null;
+  return normalizeSettings(row && row.settings);
+}
+
+// Validate + fill defaults. Accepts a JSON string or nullish; never throws.
+function normalizeSettings(raw) {
+  let s = {};
+  if (raw) { try { s = JSON.parse(raw) || {}; } catch (_) { s = {}; } }
+  let checkinMin = Math.round(Number(s.checkinMin));
+  if (!Number.isFinite(checkinMin)) checkinMin = DEFAULT_CHECKIN_MIN;
+  checkinMin = Math.min(480, Math.max(1, checkinMin));
+  const presets = DEFAULT_PRESETS.map((d, i) => {
+    const p = Array.isArray(s.presets) ? s.presets[i] : null;
+    const label = p && typeof p.label === "string" && p.label.trim() ? p.label.trim().slice(0, 40) : d.label;
+    const emoji = p && typeof p.emoji === "string" && p.emoji.trim() ? p.emoji.trim().slice(0, 8) : d.emoji;
+    return { key: d.key, label, emoji, sub: d.sub };
+  });
+  let bgColor = null;
+  if (typeof s.bgColor === "string" && /^#[0-9a-fA-F]{6}$/.test(s.bgColor.trim())) bgColor = s.bgColor.trim().toLowerCase();
+  return { checkinMin, presets, bgColor };
 }
 
 /* ============================================================
@@ -922,7 +992,7 @@ async function ensureSchema(env) {
   await env.DB.batch([
     env.DB.prepare(
       "CREATE TABLE IF NOT EXISTS companies (" +
-      "id TEXT PRIMARY KEY, name TEXT NOT NULL, code TEXT NOT NULL UNIQUE, created_at INTEGER NOT NULL)"
+      "id TEXT PRIMARY KEY, name TEXT NOT NULL, code TEXT NOT NULL UNIQUE, settings TEXT, created_at INTEGER NOT NULL)"
     ),
     env.DB.prepare(
       "CREATE TABLE IF NOT EXISTS admins (" +
@@ -964,6 +1034,7 @@ async function ensureSchema(env) {
   for (const alt of [
     "ALTER TABLE workers ADD COLUMN tz_offset INTEGER NOT NULL DEFAULT 0",
     "ALTER TABLE entries ADD COLUMN checkin_at INTEGER",
+    "ALTER TABLE companies ADD COLUMN settings TEXT",
   ]) { try { await env.DB.prepare(alt).run(); } catch (_) { /* already exists */ } }
   schemaReady = true;
 }

--- a/time/README.md
+++ b/time/README.md
@@ -60,6 +60,15 @@ computer sleeps or the app is closed and reopened.
 
 Sign-in is always **email + a 6-digit code** — no passwords.
 
+### Per-company settings (Reports → Settings tab)
+Each company's admin (and any super admin) can tailor their company from the
+**Settings** tab:
+- **Nudge interval** — how often to ask "still on this?" (any value 1–480 min; default 30).
+- **The three quick-pick tiles** — rename them and change their emoji (e.g. Calls / Email / Coffee). The once-a-day rule still applies per tile.
+- **Background color** — an optional color for the worker's app (a native color picker). Leave it unchecked for the default dark theme.
+
+Workers pick up changes automatically on their next refresh.
+
 ---
 
 ## Setup, start to finish

--- a/time/app.js
+++ b/time/app.js
@@ -17,12 +17,13 @@
   /* ---- Config ---- */
   // Served from GitHub Pages -> talk to the Worker; served by the Worker -> same-origin.
   var API_BASE = location.hostname === "time.linearit.co" ? "" : "https://time.linearit.co";
-  var CHECKIN_MS = (parseInt(localStorage.getItem("lt_checkin_min"), 10) || 30) * 60 * 1000;
-  var PRESET_META = {
-    breakfast: { emoji: "🍳", label: "Breakfast", sub: "Grab a bite" },
-    exercise:  { emoji: "🏃", label: "Exercise",  sub: "Move a little" },
-    break:     { emoji: "☕", label: "Break",     sub: "Recharge" },
-  };
+  var CHECKIN_MS = 30 * 60 * 1000;   // default; overridden per company from /api/day
+  // Fallback tiles if the server hasn't sent the company's customized ones yet.
+  var DEFAULT_PRESETS_META = [
+    { key: "breakfast", emoji: "🍳", label: "Breakfast", sub: "Grab a bite" },
+    { key: "exercise",  emoji: "🏃", label: "Exercise",  sub: "Move a little" },
+    { key: "break",     emoji: "☕", label: "Break",     sub: "Recharge" },
+  ];
 
   /* ---- Persisted session ---- */
   function getToken() { return localStorage.getItem("lt_token") || ""; }
@@ -40,6 +41,7 @@
   var T = null;            // tracker state
   function freshTracker() {
     return { day: todayStr(), entries: [], running: null, presetsUsed: [], presets: ["breakfast", "exercise", "break"],
+      presetsMeta: DEFAULT_PRESETS_META, bgColor: null,
       skew: 0, picking: false, modalOpen: false, dayEnded: false, wrapHour: 17, wrapSnoozeUntil: 0 };
   }
   var A = null;            // admin state
@@ -144,6 +146,7 @@
   }
   function routeToAuth() {
     stopTicker(); T = null; A = null;
+    applyBg(null);
     showView("auth");
     $("auth-code").classList.add("hidden");
     $("auth-email").classList.remove("hidden");
@@ -220,6 +223,10 @@
       T.running = d.running || null;
       T.presetsUsed = d.presetsUsed || [];
       T.presets = d.presets || T.presets;
+      T.presetsMeta = (d.presetsMeta && d.presetsMeta.length) ? d.presetsMeta : DEFAULT_PRESETS_META;
+      if (d.checkinMin) CHECKIN_MS = d.checkinMin * 60000;
+      T.bgColor = d.bgColor || null;
+      applyBg(T.bgColor);
       T.dayEnded = !!d.dayEnded;
       T.wrapHour = d.wrapHour || 17;
       if (d.profile && d.profile.name) {
@@ -281,13 +288,12 @@
     var hasStuff = T.entries.length > 0 || T.running;
     $("prompt-title").textContent = T.picking ? "Switch to…" : (hasStuff ? "What's next?" : "What's your first task?");
     var tiles = $("preset-tiles"); clear(tiles);
-    T.presets.forEach(function (key) {
-      if (T.presetsUsed.indexOf(key) !== -1) return; // once-a-day: hide if already logged today
-      var m = PRESET_META[key] || { emoji: "•", label: cap(key), sub: "" };
-      tiles.appendChild(el("button", { class: "tile", onclick: function () { startTask(m.label, key); } }, [
-        el("span", { class: "emoji", text: m.emoji }),
+    (T.presetsMeta || DEFAULT_PRESETS_META).forEach(function (m) {
+      if (T.presetsUsed.indexOf(m.key) !== -1) return; // once-a-day: hide if already logged today
+      tiles.appendChild(el("button", { class: "tile", onclick: function () { startTask(m.label, m.key); } }, [
+        el("span", { class: "emoji", text: m.emoji || "•" }),
         el("span", { class: "t", text: m.label }),
-        el("span", { class: "s", text: m.sub }),
+        el("span", { class: "s", text: m.sub || "" }),
       ]));
     });
     // If switching, offer a way back to the current task.
@@ -529,8 +535,8 @@
   function renderAdminTabs() {
     var host = $("admin-tabs"); clear(host);
     var tabs = A.role === "super"
-      ? [["reports", "Reports"], ["workers", "People"], ["companies", "Companies"], ["admins", "Admins"]]
-      : [["reports", "Reports"], ["workers", "People"]];
+      ? [["reports", "Reports"], ["workers", "People"], ["settings", "Settings"], ["companies", "Companies"], ["admins", "Admins"]]
+      : [["reports", "Reports"], ["workers", "People"], ["settings", "Settings"]];
     tabs.forEach(function (t) {
       host.appendChild(el("button", { class: "tab" + (A.tab === t[0] ? " active" : ""), text: t[1], onclick: function () { selectTab(t[0]); } }, []));
     });
@@ -539,6 +545,7 @@
     A.tab = name; renderAdminTabs();
     if (name === "reports") renderReports();
     else if (name === "workers") renderWorkersTab();
+    else if (name === "settings") renderSettingsTab();
     else if (name === "companies") renderCompaniesTab();
     else if (name === "admins") renderAdminsTab();
   }
@@ -702,6 +709,82 @@
     } catch (e) { toast(e.error || "Couldn't rename."); }
   }
 
+  /* ---- Settings tab (per company) ---- */
+  async function renderSettingsTab() {
+    var body = $("admin-body"); clear(body);
+    var companyId = A.role === "super" ? (A.setCompany || (A.companies[0] && A.companies[0].id) || "") : A.selCompany;
+    A.setCompany = companyId;
+
+    var wrap = el("div", { class: "panel" }, [el("h2", { text: "Settings" }, []), el("div", { class: "empty", text: "Loading…" }, [])]);
+    body.appendChild(wrap);
+    if (A.role === "super" && !A.companies.length) {
+      clear(wrap); wrap.appendChild(el("h2", { text: "Settings" }, []));
+      wrap.appendChild(el("div", { class: "empty", text: "Create a company first (Companies tab)." }, [])); return;
+    }
+    try {
+      var r = await api("/api/admin/settings?company_id=" + encodeURIComponent(companyId));
+      var s = r.settings;
+      clear(wrap);
+
+      var header = el("div", { class: "panel-head" }, [el("h2", { style: "margin:0", text: "Settings" }, [])]);
+      if (A.role === "super") {
+        var sel = el("select", { style: "max-width:220px", onchange: function () { A.setCompany = this.value; renderSettingsTab(); } }, companyOptions(false));
+        sel.value = companyId;
+        header.appendChild(sel);
+      }
+      wrap.appendChild(header);
+
+      // Nudge interval
+      var intervalIn = el("input", { type: "text", inputmode: "numeric", value: String(s.checkinMin) }, []);
+      wrap.appendChild(el("label", { class: "field" }, [
+        el("span", { class: "lbl", text: "Nudge every … minutes" }, []),
+        intervalIn,
+        el("span", { class: "hint", text: "How often to ask “still on this?” — e.g. 20 for more often, 45 for less. Any value 1–480." }, []),
+      ]));
+
+      // The three tiles
+      wrap.appendChild(el("div", { class: "lbl", style: "font-size:13px;font-weight:600;color:var(--muted);margin:6px 0 8px", text: "The three quick-pick tiles (emoji + name)" }, []));
+      var presetInputs = [];
+      (s.presets || []).forEach(function (p) {
+        var emojiIn = el("input", { type: "text", value: p.emoji, maxlength: "8", style: "text-align:center" }, []);
+        var labelIn = el("input", { type: "text", value: p.label, maxlength: "40" }, []);
+        presetInputs.push({ emoji: emojiIn, label: labelIn });
+        wrap.appendChild(el("div", { class: "row", style: "margin-bottom:10px" }, [
+          el("div", { style: "flex:0 0 70px;min-width:0" }, [emojiIn]),
+          el("div", { style: "flex:1 1 auto;min-width:140px" }, [labelIn]),
+        ]));
+      });
+
+      // Optional background color
+      var useColor = el("input", { type: "checkbox" }, []); useColor.checked = !!s.bgColor;
+      var colorIn = el("input", { type: "color", value: s.bgColor || "#0f1117",
+        style: "width:56px;height:38px;padding:2px;border-radius:8px;border:1px solid var(--border2);background:var(--input-bg);cursor:pointer" }, []);
+      colorIn.disabled = !s.bgColor;
+      useColor.addEventListener("change", function () { colorIn.disabled = !useColor.checked; });
+      wrap.appendChild(el("label", { class: "field", style: "margin-top:12px;display:flex;align-items:center;gap:10px;flex-wrap:wrap" }, [
+        useColor, el("span", { class: "lbl", style: "margin:0", text: "Custom background color" }, []), colorIn,
+      ]));
+      wrap.appendChild(el("span", { class: "hint", style: "display:block;margin-top:-6px", text: "Optional — leave unchecked for the default. Darker shades keep text readable." }, []));
+
+      var errEl = el("div", { class: "err" }, []);
+      wrap.appendChild(el("button", { class: "btn", style: "margin-top:14px", text: "Save settings", onclick: async function () {
+        errEl.textContent = "";
+        var mins = parseInt(intervalIn.value, 10);
+        if (!mins || mins < 1 || mins > 480) { errEl.textContent = "Enter a nudge interval between 1 and 480 minutes."; return; }
+        var presets = presetInputs.map(function (pi) { return { emoji: pi.emoji.value.trim(), label: pi.label.value.trim() }; });
+        if (presets.some(function (p) { return !p.label; })) { errEl.textContent = "Each tile needs a name."; return; }
+        try {
+          await api("/api/admin/settings", { method: "POST", body: { company_id: companyId, checkinMin: mins, presets: presets, bgColor: useColor.checked ? colorIn.value : null } });
+          toast("Settings saved — workers pick them up on their next refresh.");
+        } catch (e) { errEl.textContent = e.error || "Couldn't save."; }
+      } }, []));
+      wrap.appendChild(errEl);
+    } catch (e) {
+      clear(wrap); wrap.appendChild(el("h2", { text: "Settings" }, []));
+      wrap.appendChild(el("div", { class: "empty", text: e.error || "Couldn't load." }, []));
+    }
+  }
+
   /* ---- Companies tab (super only) ---- */
   async function renderCompaniesTab() {
     var body = $("admin-body"); clear(body);
@@ -797,6 +880,18 @@
   function copy(text) {
     if (navigator.clipboard) navigator.clipboard.writeText(text).then(function () { toast("Copied " + text); }, function () { toast(text); });
     else toast(text);
+  }
+  // Apply (or clear) a company's custom background color. Content sits on cards, so
+  // only the page backdrop changes; we also hide the pattern so the color reads clean.
+  function applyBg(color) {
+    var root = document.documentElement;
+    if (color && /^#[0-9a-fA-F]{6}$/.test(color)) {
+      root.style.setProperty("--bg", color);
+      root.setAttribute("data-custombg", "");
+    } else {
+      root.style.removeProperty("--bg");
+      root.removeAttribute("data-custombg");
+    }
   }
 
   /* ============================================================

--- a/time/index.html
+++ b/time/index.html
@@ -45,6 +45,7 @@ html,body{height:100%}
 body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;background:var(--bg);color:var(--text);line-height:1.5;-webkit-font-smoothing:antialiased}
 body::before{content:"";position:fixed;inset:0;z-index:-1;pointer-events:none;background:center/cover no-repeat url("/time/assets/pattern.png");opacity:.35}
 [data-theme="light"] body::before{opacity:.5}
+html[data-custombg] body::before{opacity:0}
 a{color:var(--accent)}
 button{font:inherit;cursor:pointer;border:none;background:none;color:inherit}
 input,select,textarea{font:inherit}


### PR DESCRIPTION
Lets each company's admin (and super admins) tailor their company from a new **Settings** tab in the admin panel.

## What admins can change
- **Nudge interval** — the "still on this?" cadence, any value 1–480 min (previously fixed at 30).
- **The three quick-pick tiles** — relabel them and change their emoji (e.g. Calls / Email / Coffee). The three internal slot keys stay fixed so the once-a-day rule keeps working per slot.
- **Optional background color** — a native color picker; workers see it as the app backdrop. Off by default (unchecked = default dark theme).

## Implementation
- **Backend**: settings stored as JSON in `companies.settings` (schema self-migrates). `GET`/`POST /api/admin/settings`, scoped so company admins can only touch their own company. `/api/day` now returns `checkinMin`, `presetsMeta`, and `bgColor`. `taskStart`/`taskCheckin` use the company interval; the cron re-nudge throttle follows it too. All values validated/clamped server-side.
- **Frontend**: new Settings tab; the tracker renders the company's tiles, honors the interval, and applies the background (content stays on cards for readability; the pattern hides under a custom color).

## Tests
10 new checks (66 total passing): defaults, save/scoping (company admin can't affect another company), clamping/validation, and that a worker's `/api/day` + new task pick up the custom interval, tiles, and color.

Note: the Worker (Workers Builds, root `time-worker`) redeploys on merge, so the new endpoint goes live alongside the GitHub Pages frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKj7B6z8xX5vBn9TqUotTy)_