### PR TITLE
Deals: Amazon/FTC compliance — drop unverified "tested" claim

### DIFF
--- a/deals/index.html
+++ b/deals/index.html
@@ -204,7 +204,7 @@
 <section class="hero">
   <span class="eyebrow">Hand-picked by Linear IT</span>
   <h1>The Complete Home-Office Set</h1>
-  <p>Everything you need for a clean, fast desk setup — chosen and tested by our techs. Grab the whole set in one click, or pick items on their own.</p>
+  <p>Everything you need for a clean, fast desk setup — picked by our techs. Grab the whole set in one click, or pick items on their own.</p>
 </section>
 
 <main class="wrap">


### PR DESCRIPTION
Follow-up compliance pass on `/deals` after auditing the page against the Amazon Associates Operating Agreement.

The page was already compliant on the big items (affiliate disclosure present and conspicuous, no manual prices, no saved/hotlinked Amazon images, no Amazon trademark graphics, tagged links to Amazon product/cart pages, no scraped reviews).

The one fix: the hero said items were "chosen and **tested** by our techs." Softened to "picked by our techs" to avoid an unverifiable endorsement/testing claim under Amazon's no-misleading-content rule and FTC endorsement guidelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAk1byHXpEa2gvfVrEYAup

---
_Generated by [Claude Code](https://claude.ai/code/session_01KAk1byHXpEa2gvfVrEYAup)_