### PR TITLE
Deals: add "Tech-tested" badge to the PC and headset

### DIFF
--- a/deals/index.html
+++ b/deals/index.html
@@ -92,6 +92,9 @@
   .set-item:nth-child(3n){border-right:none}
   .set-num{font-size:12px;font-weight:700;color:var(--faint)}
   .set-item .emoji{font-size:22px;margin:6px 0 8px}
+  .tested{display:inline-flex;align-items:center;gap:5px;font-size:11px;font-weight:700;letter-spacing:.03em;
+    color:var(--green);background:var(--green-bg);border:1px solid rgba(74,222,128,.3);
+    padding:3px 9px;border-radius:999px;width:fit-content;margin-bottom:8px}
   .set-item h4{font-size:16px;margin:0 0 4px}
   .set-item p{color:var(--muted);font-size:13.5px;flex:1;margin:0 0 14px}
   .ilink{display:inline-flex;align-items:center;gap:6px;font-size:13.5px;font-weight:600;color:var(--brand);margin-top:auto}
@@ -229,6 +232,7 @@
       <div class="set-item">
         <div class="set-num">01</div>
         <div class="emoji">💻</div>
+        <span class="tested">✓ Tech-tested</span>
         <h4>Mini PC</h4>
         <p>16GB RAM + SSD. Small, quiet, and quick for email, Office, browsing, and Zoom.</p>
         <a class="ilink" href="https://amzn.to/4g1gEv1" target="_blank" rel="nofollow sponsored noopener">View on Amazon →</a>
@@ -281,6 +285,7 @@
         <div class="ah">
           <span class="ico">🎧</span>
           <span class="t">Add a Headset</span>
+          <span class="tested" style="margin-bottom:0">✓ Tech-tested</span>
           <span class="opt">Optional</span>
         </div>
         <p>Clearer mic and less background noise for Zoom, Teams, and support calls. Want it in the bundle? Add the set plus a headset in one click.</p>


### PR DESCRIPTION
The mini PC and headset were actually hands-on tested; the cables, monitor, and keyboard were not. So instead of a blanket "tested" claim, this adds a green "✓ Tech-tested" badge to just those two items — accurate and compliant with Amazon's no-misleading-content rule and FTC endorsement guidelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAk1byHXpEa2gvfVrEYAup

---
_Generated by [Claude Code](https://claude.ai/code/session_01KAk1byHXpEa2gvfVrEYAup)_