### PR TITLE
Name the speed Worker after the folder it lives in

### DIFF
--- a/speed-worker/README.md
+++ b/speed-worker/README.md
@@ -1,4 +1,4 @@
-# `linear-speed` — Cloudflare Worker for `speed.linearit.co`
+# `speed-worker` — Cloudflare Worker for `speed.linearit.co`
 
 The measurement backend for **Linear Speed**, the branded speed test. The app
 itself lives in this repo at `/speed/` (served by GitHub Pages at
@@ -27,7 +27,7 @@ npx wrangler deploy
 
 That single `deploy`:
 
-1. Uploads the `linear-speed` Worker.
+1. Uploads the `speed-worker` Worker.
 2. Because `wrangler.toml` has `{ pattern = "speed.linearit.co", custom_domain = true }`,
    it **creates the `speed.linearit.co` Custom Domain and its DNS record**
    automatically in the `linearit.co` zone.

--- a/speed-worker/package.json
+++ b/speed-worker/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "linear-speed-worker",
+  "name": "speed-worker",
   "version": "1.0.0",
   "private": true,
   "description": "Cloudflare Worker for Linear Speed (speed.linearit.co) — the speed test measurement endpoints.",

--- a/speed-worker/src/index.js
+++ b/speed-worker/src/index.js
@@ -1,5 +1,5 @@
 /**
- * `linear-speed` — Cloudflare Worker for speed.linearit.co
+ * `speed-worker` — Cloudflare Worker for speed.linearit.co
  * ========================================================
  *
  * The measurement backend for **Linear Speed**, the branded speed test. It does
@@ -178,7 +178,7 @@ async function proxyApp(request, env, url, method) {
   headers.set("X-Content-Type-Options", "nosniff");
   headers.set("Referrer-Policy", "no-referrer");
   headers.set("Cache-Control", "no-store, must-revalidate");
-  headers.set("X-Served-By", "linear-speed");
+  headers.set("X-Served-By", "speed-worker");
   const body = method === "HEAD" ? null : originResp.body;
   return new Response(body, { status: originResp.status, statusText: originResp.statusText, headers });
 }

--- a/speed-worker/wrangler.toml
+++ b/speed-worker/wrangler.toml
@@ -16,7 +16,7 @@
 # DNS record automatically in the linearit.co zone (because of custom_domain =
 # true). Validate without deploying with `npx wrangler deploy --dry-run`.
 
-name = "linear-speed"
+name = "speed-worker"
 main = "src/index.js"
 compatibility_date = "2025-06-01"
 


### PR DESCRIPTION
The Worker created in Cloudflare is called **`speed-worker`**, but `speed-worker/wrangler.toml` declared `name = "linear-speed"`.

A Workers Build deploying a Worker whose config name differs from the Worker it belongs to can fail on the mismatch, and Cloudflare Workers cannot be renamed after creation. So the config moves to match the Worker rather than the other way round. It also lines the Worker name up with the folder name, which is one less thing to keep straight.

No behaviour changes — only the declared name, the `X-Served-By` header, the package name and the docs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAjWLKqmFLNj7KszJwJP6i)_